### PR TITLE
fix: divide expected improvement by predicted time in AcqFunctionEIPS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # mlr3mbo (development version)
 
+* fix: `AcqFunctionEIPS` now correctly divides the expected improvement by the predicted time instead of behaving like plain expected improvement.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
 
 # mlr3mbo 1.1.1

--- a/R/AcqFunctionEIPS.R
+++ b/R/AcqFunctionEIPS.R
@@ -127,8 +127,7 @@ AcqFunctionEIPS = R6Class(
       d = self$y_best - self$surrogate_max_to_min[[self$col_y]] * mu
       d_norm = d / se
       ei = d * pnorm(d_norm) + se * dnorm(d_norm)
-      eips = ei / mu_t
-      eips = ifelse(se < 1e-20 | mu_t < 1e-20, 0, ei)
+      eips = ifelse(se < 1e-20 | mu_t < 1e-20, 0, ei / mu_t)
       data.table(acq_eips = eips)
     }
   )

--- a/tests/testthat/test_AcqFunctionEIPS.R
+++ b/tests/testthat/test_AcqFunctionEIPS.R
@@ -31,4 +31,16 @@ test_that("AcqFunctionEIPS works", {
   res = acqf$eval_dt(xdt)
   expect_data_table(res, ncols = 1L, nrows = 5L, any.missing = FALSE)
   expect_named(res, acqf$id)
+
+  # eips must actually divide expected improvement by the predicted time
+  p = acqf$surrogate$predict(xdt)
+  mu = p[[acqf$col_y]]$mean
+  se = p[[acqf$col_y]]$se
+  mu_t = p[[acqf$col_time]]$mean
+  d = acqf$y_best - acqf$surrogate_max_to_min[[acqf$col_y]] * mu
+  d_norm = d / se
+  ei = d * pnorm(d_norm) + se * dnorm(d_norm)
+  expected_eips = ifelse(se < 1e-20 | mu_t < 1e-20, 0, ei / mu_t)
+  expect_equal(res[[acqf$id]], expected_eips)
+  expect_false(isTRUE(all.equal(res[[acqf$id]], ei)))
 })


### PR DESCRIPTION
## Summary

`AcqFunctionEIPS` (expected improvement *per second*) was silently behaving like plain `AcqFunctionEI`. In `.fun`, two consecutive assignments to `eips` meant the second one won — and it used `ei` rather than `ei / mu_t`:

```r
eips = ei / mu_t
eips = ifelse(se < 1e-20 | mu_t < 1e-20, 0, ei)   # overwrites, drops the division
```

The division by the predicted time was dead code, so the entire point of the class did not exist. The bug was invisible to the test suite because `test_AcqFunctionEIPS.R` only checked shapes and names with a featureless learner.

## Fix

Collapse the guard and the division into a single assignment:

```r
eips = ifelse(se < 1e-20 | mu_t < 1e-20, 0, ei / mu_t)
```

## Tests

Added a value-level assertion to `test_AcqFunctionEIPS.R` that recomputes the expected `eips` from the surrogate predictions and asserts it equals the acquisition output and differs from plain expected improvement. This guards against the regression returning silently. All EIPS tests pass (17 assertions).

## Note

The review (Issue 1) also flagged that `mu_t` is ill-defined under an output trafo with `invert_posterior = FALSE`, since `update()` transforms the time column too, making a standardized (possibly negative) "time" a nonsensical divisor. That is a separate design decision and is left out of scope here; this PR restores the core documented behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)