### PR TITLE
fix: transform ys_front onto output trafo scale in multi-objective acqfs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # mlr3mbo (development version)
 
+* fix: `AcqFunctionEHVI`, `AcqFunctionEHVIGH`, and `AcqFunctionSmsEgo` now apply the surrogate's output transformation to `ys_front`, so the front and the reference point are compared on the same scale.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
 
 # mlr3mbo 1.1.1

--- a/R/AcqFunctionEHVI.R
+++ b/R/AcqFunctionEHVI.R
@@ -101,6 +101,9 @@ AcqFunctionEHVI = R6Class(
       self$ref_point = apply(ys, MARGIN = 2L, FUN = max) + 1 # offset = 1 like in mlrMBO
 
       self$ys_front = self$archive$best()[, self$archive$cols_y, with = FALSE]
+      if (self$surrogate$output_trafo_must_be_considered) {
+        self$ys_front = self$surrogate$output_trafo$transform(self$ys_front)
+      }
       for (column in self$archive$cols_y) {
         # assume minimization
         set(self$ys_front, j = column, value = self$ys_front[[column]] * self$surrogate_max_to_min[[column]])

--- a/R/AcqFunctionEHVIGH.R
+++ b/R/AcqFunctionEHVIGH.R
@@ -130,6 +130,9 @@ AcqFunctionEHVIGH = R6Class(
       self$ref_point = apply(ys, MARGIN = 2L, FUN = max) + 1 # offset = 1 like in mlrMBO
 
       self$ys_front = self$archive$best()[, self$archive$cols_y, with = FALSE]
+      if (self$surrogate$output_trafo_must_be_considered) {
+        self$ys_front = self$surrogate$output_trafo$transform(self$ys_front)
+      }
       for (column in self$archive$cols_y) {
         # assume minimization
         set(self$ys_front, j = column, value = self$ys_front[[column]] * self$surrogate_max_to_min[[column]])

--- a/R/AcqFunctionSmsEgo.R
+++ b/R/AcqFunctionSmsEgo.R
@@ -140,6 +140,9 @@ AcqFunctionSmsEgo = R6Class(
       self$ref_point = apply(ys, MARGIN = 2L, FUN = max) + 1 # offset = 1 like in mlrMBO
 
       self$ys_front = self$archive$best()[, self$archive$cols_y, with = FALSE]
+      if (self$surrogate$output_trafo_must_be_considered) {
+        self$ys_front = self$surrogate$output_trafo$transform(self$ys_front)
+      }
       for (column in self$archive$cols_y) {
         # assume minimization
         set(self$ys_front, j = column, value = self$ys_front[[column]] * self$surrogate_max_to_min[[column]])

--- a/tests/testthat/test_AcqFunctionEHVI.R
+++ b/tests/testthat/test_AcqFunctionEHVI.R
@@ -27,3 +27,31 @@ test_that("AcqFunctionEHVI works", {
   expect_named(res, acqf$id)
   expect_true(all(res[[acqf$id]] >= 0))
 })
+
+test_that("AcqFunctionEHVI transforms ys_front onto the output trafo scale", {
+  inst = MAKE_INST(OBJ_1D_2, PS_1D, trm("evals", n_evals = 5L))
+  surrogate = SurrogateLearnerCollection$new(
+    list(REGR_FEATURELESS, REGR_FEATURELESS$clone(deep = TRUE)),
+    archive = inst$archive
+  )
+  ot = OutputTrafoStandardize$new()
+  ot$invert_posterior = FALSE
+  surrogate$output_trafo = ot
+  acqf = AcqFunctionEHVI$new(surrogate = surrogate)
+
+  design = MAKE_DESIGN(inst)
+  inst$eval_batch(design)
+
+  acqf$surrogate$update()
+  expect_true(surrogate$output_trafo_must_be_considered)
+  acqf$update()
+
+  expected = ot$transform(inst$archive$best()[, inst$archive$cols_y, with = FALSE])
+  for (col in inst$archive$cols_y) {
+    set(expected, j = col, value = expected[[col]] * acqf$surrogate_max_to_min[[col]])
+  }
+  setorderv(expected, cols = inst$archive$cols_y[1L], order = -1L)
+  expect_equal(acqf$ys_front, as.matrix(expected))
+  # ys_front and ref_point must live on the same (transformed) scale
+  expect_true(all(apply(acqf$ys_front, 2L, max) <= acqf$ref_point))
+})

--- a/tests/testthat/test_AcqFunctionEHVIGH.R
+++ b/tests/testthat/test_AcqFunctionEHVIGH.R
@@ -34,6 +34,34 @@ test_that("AcqFunctionEHVIGH works", {
   expect_true(all(res[[acqf$id]] >= 0))
 })
 
+test_that("AcqFunctionEHVIGH transforms ys_front onto the output trafo scale", {
+  skip_if_not_installed("emoa")
+  skip_if_not_installed("fastGHQuad")
+  inst = MAKE_INST(OBJ_1D_2, PS_1D, trm("evals", n_evals = 5L))
+  surrogate = SurrogateLearnerCollection$new(
+    list(REGR_FEATURELESS, REGR_FEATURELESS$clone(deep = TRUE)),
+    archive = inst$archive
+  )
+  ot = OutputTrafoStandardize$new()
+  ot$invert_posterior = FALSE
+  surrogate$output_trafo = ot
+  acqf = AcqFunctionEHVIGH$new(surrogate = surrogate)
+
+  design = MAKE_DESIGN(inst)
+  inst$eval_batch(design)
+
+  acqf$surrogate$update()
+  expect_true(surrogate$output_trafo_must_be_considered)
+  acqf$update()
+
+  expected = ot$transform(inst$archive$best()[, inst$archive$cols_y, with = FALSE])
+  for (col in inst$archive$cols_y) {
+    set(expected, j = col, value = expected[[col]] * acqf$surrogate_max_to_min[[col]])
+  }
+  expect_equal(acqf$ys_front, as.matrix(expected))
+  expect_true(all(apply(acqf$ys_front, 2L, max) <= acqf$ref_point))
+})
+
 test_that("AcqFunctionEHVIGH is close to AcqFunctionEHVI", {
   skip_on_cran()
   skip_if_not_installed("mlr3learners")

--- a/tests/testthat/test_AcqFunctionSmsEgo.R
+++ b/tests/testthat/test_AcqFunctionSmsEgo.R
@@ -32,3 +32,30 @@ test_that("AcqFunctionSmsEgo works", {
   expect_named(res)
   expect_setequal(colnames(res), c(acqf$id, "acq_epsilon"))
 })
+
+test_that("AcqFunctionSmsEgo transforms ys_front onto the output trafo scale", {
+  inst = MAKE_INST(OBJ_1D_2, PS_1D, trm("evals", n_evals = 5L))
+  surrogate = SurrogateLearnerCollection$new(
+    list(REGR_FEATURELESS, REGR_FEATURELESS$clone(deep = TRUE)),
+    archive = inst$archive
+  )
+  ot = OutputTrafoStandardize$new()
+  ot$invert_posterior = FALSE
+  surrogate$output_trafo = ot
+  acqf = AcqFunctionSmsEgo$new(surrogate = surrogate)
+
+  design = MAKE_DESIGN(inst)
+  inst$eval_batch(design)
+
+  acqf$surrogate$update()
+  expect_true(surrogate$output_trafo_must_be_considered)
+  acqf$progress = 1
+  acqf$update()
+
+  expected = ot$transform(inst$archive$best()[, inst$archive$cols_y, with = FALSE])
+  for (col in inst$archive$cols_y) {
+    set(expected, j = col, value = expected[[col]] * acqf$surrogate_max_to_min[[col]])
+  }
+  expect_equal(acqf$ys_front, as.matrix(expected))
+  expect_true(all(apply(acqf$ys_front, 2L, max) <= acqf$ref_point))
+})


### PR DESCRIPTION
## Summary

Fixes Issue 2 from the code review. `AcqFunctionEHVI`, `AcqFunctionEHVIGH`, and `AcqFunctionSmsEgo` mixed output-trafo scales in their `update()` methods:

- `ref_point` was computed from **output-transformed** objective values.
- `ys_front` was derived from `archive$best()` on the **raw** scale and never transformed.

With an output trafo using `invert_posterior = FALSE` (so `output_trafo_must_be_considered` is `TRUE`), the surrogate predictions and `ref_point` live on the transformed scale, while `ys_front` did not. `.fun` then compared transformed-scale surrogate predictions against a raw-scale front, silently producing garbage hypervolume contributions.

The transform was only applied to the `ref_point` branch — copy-paste drift; the single-objective classes all transform `y` before computing `y_best`.

## Fix

Apply `output_trafo$transform()` to the `archive$best()` result before the sign correction in all three `update()` methods:

```r
self$ys_front = self$archive$best()[, self$archive$cols_y, with = FALSE]
if (self$surrogate$output_trafo_must_be_considered) {
  self$ys_front = self$surrogate$output_trafo$transform(self$ys_front)
}
```

`OutputTrafo$transform()` copies its input and returns a fresh `data.table`, so the subsequent in-place `set()` sign correction remains safe. Because the standardize/log transforms are monotonic, the non-dominated set is unchanged; only the scale is corrected.

## Tests

Added a value-level test to each of the three acquisition functions. Each configures a `SurrogateLearnerCollection` with `OutputTrafoStandardize` (`invert_posterior = FALSE`), then asserts:

- `ys_front` equals the manually transformed-and-sign-corrected best front, and
- the front and `ref_point` live on the same scale (`max(ys_front) <= ref_point` per column).

Confirmed each test **fails against the pre-fix code** (raw front values) and passes after the fix. Full EHVI/EHVIGH/SmsEgo suites pass (64 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)