### PR TITLE
fix: add label and man fields to AcqOptimizer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # mlr3mbo (development version)
 
+* fix: `AcqOptimizer` and its subclasses gained `$label` and `$man` fields, so that `as.data.table(mlr_acqoptimizers)` no longer errors.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
 
 # mlr3mbo 1.1.1

--- a/R/AcqOptimizer.R
+++ b/R/AcqOptimizer.R
@@ -297,6 +297,18 @@ AcqOptimizer = R6Class(
       }
     },
 
+    #' @template field_label
+    label = function(rhs) {
+      assert_ro_binding(rhs)
+      self$optimizer$label
+    },
+
+    #' @template field_man
+    man = function(rhs) {
+      assert_ro_binding(rhs)
+      "mlr3mbo::AcqOptimizer"
+    },
+
     #' @field param_set ([paradox::ParamSet])\cr
     #'   Set of hyperparameters.
     param_set = function(rhs) {

--- a/R/AcqOptimizerDirect.R
+++ b/R/AcqOptimizerDirect.R
@@ -189,6 +189,18 @@ AcqOptimizerDirect = R6Class(
     print_id = function(rhs) {
       assert_ro_binding(rhs)
       "(OptimizerDirect)"
+    },
+
+    #' @template field_label
+    label = function(rhs) {
+      assert_ro_binding(rhs)
+      "DIRECT"
+    },
+
+    #' @template field_man
+    man = function(rhs) {
+      assert_ro_binding(rhs)
+      "mlr3mbo::AcqOptimizerDirect"
     }
   )
 )

--- a/R/AcqOptimizerLbfgsb.R
+++ b/R/AcqOptimizerLbfgsb.R
@@ -194,6 +194,18 @@ AcqOptimizerLbfgsb = R6Class(
     print_id = function(rhs) {
       assert_ro_binding(rhs)
       "(OptimizerLbfgsb)"
+    },
+
+    #' @template field_label
+    label = function(rhs) {
+      assert_ro_binding(rhs)
+      "L-BFGS-B"
+    },
+
+    #' @template field_man
+    man = function(rhs) {
+      assert_ro_binding(rhs)
+      "mlr3mbo::AcqOptimizerLbfgsb"
     }
   )
 )

--- a/R/AcqOptimizerLocalSearch.R
+++ b/R/AcqOptimizerLocalSearch.R
@@ -86,6 +86,18 @@ AcqOptimizerLocalSearch = R6Class(
     print_id = function(rhs) {
       assert_ro_binding(rhs)
       "(OptimizerLocalSearch)"
+    },
+
+    #' @template field_label
+    label = function(rhs) {
+      assert_ro_binding(rhs)
+      "Local Search"
+    },
+
+    #' @template field_man
+    man = function(rhs) {
+      assert_ro_binding(rhs)
+      "mlr3mbo::AcqOptimizerLocalSearch"
     }
   ),
 

--- a/R/AcqOptimizerRandomSearch.R
+++ b/R/AcqOptimizerRandomSearch.R
@@ -80,6 +80,18 @@ AcqOptimizerRandomSearch = R6Class(
     print_id = function(rhs) {
       assert_ro_binding(rhs)
       "(OptimizerRandomSearch)"
+    },
+
+    #' @template field_label
+    label = function(rhs) {
+      assert_ro_binding(rhs)
+      "Random Search"
+    },
+
+    #' @template field_man
+    man = function(rhs) {
+      assert_ro_binding(rhs)
+      "mlr3mbo::AcqOptimizerRandomSearch"
     }
   ),
 

--- a/man-roxygen/field_label.R
+++ b/man-roxygen/field_label.R
@@ -1,0 +1,3 @@
+#' @field label (`character(1)`)\cr
+#'   Label for this object.
+#'   Can be used in tables, plot and text output instead of the ID.

--- a/man-roxygen/field_man.R
+++ b/man-roxygen/field_man.R
@@ -1,0 +1,2 @@
+#' @field man (`character(1)`)\cr
+#'   String in the format `[pkg]::[topic]` pointing to a manual page for this object.

--- a/man/AcqOptimizer.Rd
+++ b/man/AcqOptimizer.Rd
@@ -118,6 +118,13 @@ if (requireNamespace("mlr3learners") &
     \item{\code{print_id}}{(\code{character})\cr
 Id used when printing.}
 
+    \item{\code{label}}{(\code{character(1)})\cr
+Label for this object.
+Can be used in tables, plot and text output instead of the ID.}
+
+    \item{\code{man}}{(\code{character(1)})\cr
+String in the format \verb{[pkg]::[topic]} pointing to a manual page for this object.}
+
     \item{\code{param_set}}{(\link[paradox:ParamSet]{paradox::ParamSet})\cr
 Set of hyperparameters.}
   }

--- a/man/AcqOptimizerDirect.Rd
+++ b/man/AcqOptimizerDirect.Rd
@@ -82,6 +82,13 @@ List of \code{\link[nloptr:nloptr]{nloptr::nloptr()}} results.}
   \describe{
     \item{\code{print_id}}{(\code{character})\cr
 Id used when printing.}
+
+    \item{\code{label}}{(\code{character(1)})\cr
+Label for this object.
+Can be used in tables, plot and text output instead of the ID.}
+
+    \item{\code{man}}{(\code{character(1)})\cr
+String in the format \verb{[pkg]::[topic]} pointing to a manual page for this object.}
   }
   \if{html}{\out{</div>}}
 }

--- a/man/AcqOptimizerLbfgsb.Rd
+++ b/man/AcqOptimizerLbfgsb.Rd
@@ -82,6 +82,13 @@ List of \code{\link[nloptr:nloptr]{nloptr::nloptr()}} results.}
   \describe{
     \item{\code{print_id}}{(\code{character})\cr
 Id used when printing.}
+
+    \item{\code{label}}{(\code{character(1)})\cr
+Label for this object.
+Can be used in tables, plot and text output instead of the ID.}
+
+    \item{\code{man}}{(\code{character(1)})\cr
+String in the format \verb{[pkg]::[topic]} pointing to a manual page for this object.}
   }
   \if{html}{\out{</div>}}
 }

--- a/man/AcqOptimizerLocalSearch.Rd
+++ b/man/AcqOptimizerLocalSearch.Rd
@@ -28,6 +28,13 @@ List of \code{\link[cmaes:cma_es]{cmaes::cma_es()}} results.}
   \describe{
     \item{\code{print_id}}{(\code{character})\cr
 Id used when printing.}
+
+    \item{\code{label}}{(\code{character(1)})\cr
+Label for this object.
+Can be used in tables, plot and text output instead of the ID.}
+
+    \item{\code{man}}{(\code{character(1)})\cr
+String in the format \verb{[pkg]::[topic]} pointing to a manual page for this object.}
   }
   \if{html}{\out{</div>}}
 }

--- a/man/AcqOptimizerRandomSearch.Rd
+++ b/man/AcqOptimizerRandomSearch.Rd
@@ -28,6 +28,13 @@ acqo("random_search")
   \describe{
     \item{\code{print_id}}{(\code{character})\cr
 Id used when printing.}
+
+    \item{\code{label}}{(\code{character(1)})\cr
+Label for this object.
+Can be used in tables, plot and text output instead of the ID.}
+
+    \item{\code{man}}{(\code{character(1)})\cr
+String in the format \verb{[pkg]::[topic]} pointing to a manual page for this object.}
   }
   \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test_AcqOptimizer.R
+++ b/tests/testthat/test_AcqOptimizer.R
@@ -172,3 +172,19 @@ test_that("AcqOptimizer callbacks", {
   res = acqopt$optimize()
   expect_number(attr(instance, "acq_opt_runtime"))
 })
+
+test_that("mlr_acqoptimizers dictionary and label/man work", {
+  tab = as.data.table(mlr_acqoptimizers)
+  expect_data_table(tab, ncols = 3L)
+  expect_names(names(tab), permutation.of = c("key", "label", "man"))
+  expect_character(tab$label, any.missing = FALSE)
+  expect_character(tab$man, any.missing = FALSE)
+
+  # base AcqOptimizer derives its label from the wrapped bbotk::Optimizer
+  optimizer = opt("random_search")
+  acqopt = AcqOptimizer$new(optimizer, trm("evals", n_evals = 2L))
+  expect_equal(acqopt$label, optimizer$label)
+  expect_equal(acqopt$man, "mlr3mbo::AcqOptimizer")
+  expect_error({acqopt$label = "x"}, "read-only")
+  expect_error({acqopt$man = "x"}, "read-only")
+})


### PR DESCRIPTION
## Summary

Fixes Issue 3 from the 2026-07-17 code review: `as.data.table(mlr_acqoptimizers)` errored because `AcqOptimizer` and its subclasses had no `$label` or `$man` field, even though the `as.data.table` method (and the roxygen `@examples` of `R/mlr_acqoptimizers.R`) referenced them. This broke `R CMD check`.

## Changes

- `AcqOptimizer` (base) now exposes read-only `$label` and `$man` active bindings. Since the base class wraps a `bbotk::Optimizer`, its `$label` is derived from `self$optimizer$label`, and `$man` points to `mlr3mbo::AcqOptimizer`.
- Each subclass (`AcqOptimizerDirect`, `AcqOptimizerLbfgsb`, `AcqOptimizerLocalSearch`, `AcqOptimizerRandomSearch`) provides its own `$label` (`"DIRECT"`, `"L-BFGS-B"`, `"Local Search"`, `"Random Search"`) and `$man` reference, since they implement their own optimization rather than wrapping a `bbotk::Optimizer`.
- Added `field_label` / `field_man` roxygen templates.
- Added a test covering `as.data.table(mlr_acqoptimizers)` and the label/man bindings.
- Added a `NEWS.md` bullet.

## Test plan

- [x] `devtools::test(filter = '^AcqOptimizer')` — 81 passing, 0 failures.
- [x] `as.data.table(mlr_acqoptimizers)` now returns a `key`/`label`/`man` table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)