### PR TITLE
fix: clip x0 into the shrunk box in AcqOptimizerLbfgsb

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * fix: `AcqFunctionEHVI`, `AcqFunctionEHVIGH`, and `AcqFunctionSmsEgo` now apply the surrogate's output transformation to `ys_front`, so the front and the reference point are compared on the same scale.
 * fix: `AcqFunctionEIPS` now correctly divides the expected improvement by the predicted time instead of behaving like plain expected improvement.
+* fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
 
 # mlr3mbo 1.1.1

--- a/R/AcqOptimizerLbfgsb.R
+++ b/R/AcqOptimizerLbfgsb.R
@@ -125,6 +125,20 @@ AcqOptimizerLbfgsb = R6Class(
       constants = self$acq_function$constants$values
       direction = self$acq_function$codomain$direction
 
+      # nloptr requires x0 to lie strictly within the bounds, so we shrink the box by safeguard_epsilon on each side.
+      # Degenerate dimensions (span smaller than 2 * safeguard_epsilon) are collapsed to their midpoint to keep lb <= ub.
+      safeguard_epsilon = 1e-5
+      lower = self$acq_function$domain$lower
+      upper = self$acq_function$domain$upper
+      lb = lower + safeguard_epsilon
+      ub = upper - safeguard_epsilon
+      degenerate = lb > ub
+      if (any(degenerate)) {
+        mid = (lower + upper) / 2
+        lb[degenerate] = mid[degenerate]
+        ub[degenerate] = mid[degenerate]
+      }
+
       y = Inf
       n_evals = 0L
       n_restarts = 0L
@@ -137,18 +151,19 @@ AcqOptimizerLbfgsb = R6Class(
           # random restart
           as.numeric(generate_design_random(self$acq_function$domain, n = 1)$data)
         }
+        # clip the starting point into the shrunk box, otherwise nloptr aborts when the incumbent lies on a bound
+        x0 = pmin(pmax(x0, lb), ub)
 
         eval_grad_f = function(x, fun, constants, direction) {
           invoke(nloptr::nl.grad, x0 = x, fn = wrapper, fun = fun, constants = constants, direction = direction)
         }
-        safeguard_epsilon = 1e-5
 
         optimize = function() {
           invoke(
             nloptr::nloptr,
             eval_f = wrapper,
-            lb = self$acq_function$domain$lower + safeguard_epsilon,
-            ub = self$acq_function$domain$upper - safeguard_epsilon,
+            lb = lb,
+            ub = ub,
             opts = insert_named(pv, list(algorithm = "NLOPT_LD_LBFGS", maxeval = maxeval - n_evals)),
             eval_grad_f = eval_grad_f,
             x0 = x0,

--- a/tests/testthat/test_AcqOptimizerLbfgsb.R
+++ b/tests/testthat/test_AcqOptimizerLbfgsb.R
@@ -53,6 +53,33 @@ test_that("AcqOptimizerLbfgsb works with instance", {
   expect_data_table(optimizer$optimize(instance), nrows = 1L)
 })
 
+test_that("AcqOptimizerLbfgsb works when the incumbent lies on a search space bound", {
+  skip_if_missing_regr_km()
+  # linear objective, minimized -> the incumbent lies exactly on the lower bound
+  obj = bbotk::ObjectiveRFun$new(
+    fun = function(xs) list(y = as.numeric(xs$x)),
+    domain = PS_1D,
+    codomain = ps(y = p_dbl(tags = "minimize")),
+    properties = "single-crit"
+  )
+  instance = oi(obj, terminator = trm("evals", n_evals = 5L))
+  design = generate_design_grid(instance$search_space, resolution = 4L)$data
+  instance$eval_batch(design)
+
+  surrogate = srlrn(REGR_KM_DETERM, archive = instance$archive)
+  acqfun = acqf("ei", surrogate = surrogate)
+  acqopt = AcqOptimizerLbfgsb$new(acq_function = acqfun)
+  acqopt$param_set$set_values(maxeval = 200L, restart_strategy = "none")
+  acqfun$surrogate$update()
+  acqfun$update()
+
+  # the incumbent is at the lower bound, which used to abort nloptr with "at least one element in x0 < lb"
+  expect_equal(acqfun$archive$best()[["x"]], unname(instance$search_space$lower))
+  res = acqopt$optimize()
+  expect_data_table(res, nrows = 1L)
+  expect_number(res[["x"]], lower = instance$search_space$lower, upper = instance$search_space$upper)
+})
+
 test_that("AcqOptimizerLbfgsb works with random restart", {
   skip_if_missing_regr_km()
   instance = oi(OBJ_2D, terminator = trm("evals", n_evals = 5L))


### PR DESCRIPTION
## Problem

`AcqOptimizerLbfgsb` fails whenever the incumbent lies on a search-space bound, and BO silently degenerates to random search.

The starting point `x0` is the best archive point, which frequently lies exactly on a bound (grid and Sobol initial designs include bounds; optima at bounds are common). The bounds passed to `nloptr` are shrunk by `safeguard_epsilon = 1e-5` on each side, but `x0` was **not** clipped into the shrunk box, so `nloptr` aborts with `at least one element in x0 < lb`. Every subsequent call fails the same way; under `catch_errors = TRUE` (the default), `bayesopt_ego` catches the wrapped error and proposes a random point *every iteration* — the user gets pure random search with only a warn-level log line.

This is Blocking issue #4 from the 2026-07-17 code review.

## Fix

- Clip the starting point into the shrunk box: `x0 = pmin(pmax(x0, lb), ub)`.
- Handle degenerate dimensions whose span is smaller than `2 * safeguard_epsilon` (which would otherwise make `lb > ub`) by collapsing them to their midpoint.

The shrunk bounds are now computed once before the restart loop instead of inside the per-restart `optimize()` closure.

## Test

Added a value-level test with a linear objective whose minimum sits exactly on the lower bound, so the incumbent is guaranteed to lie on a bound. The test fails on `main` (aborts with the acq-optimizer error) and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)