### PR TITLE
fix: allow deep cloning of AcqOptimizer subclasses and AcqFunctionMulti

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * fix: `AcqFunctionEHVI`, `AcqFunctionEHVIGH`, and `AcqFunctionSmsEgo` now apply the surrogate's output transformation to `ys_front`, so the front and the reference point are compared on the same scale.
 * fix: `AcqFunctionEIPS` now correctly divides the expected improvement by the predicted time instead of behaving like plain expected improvement.
+* fix: `AcqFunctionMulti` can now be deep cloned without error and preserves the shared surrogate across the wrapped acquisition functions.
+* fix: `AcqOptimizerDirect`, `AcqOptimizerLbfgsb`, `AcqOptimizerLocalSearch`, and `AcqOptimizerRandomSearch` can now be deep cloned without error.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
 
 # mlr3mbo 1.1.1

--- a/R/AcqFunctionMulti.R
+++ b/R/AcqFunctionMulti.R
@@ -219,7 +219,11 @@ AcqFunctionMulti = R6Class(
     },
 
     deep_clone = function(name, value) {
-      switch(name, .acq_functions = value$clone(deep = TRUE), value)
+      # .acq_functions is a plain list of R6 objects and must be cloned element-wise.
+      # Cloning an AcqFunction shares its surrogate by reference (like the inherited .surrogate field),
+      # so all cloned acquisition functions keep pointing to the same shared surrogate as the parent,
+      # which preserves the shared-surrogate invariant asserted in $update().
+      switch(name, .acq_functions = map(value, function(acq_function) acq_function$clone(deep = TRUE)), value)
     }
   )
 )

--- a/R/AcqOptimizer.R
+++ b/R/AcqOptimizer.R
@@ -313,8 +313,8 @@ AcqOptimizer = R6Class(
     deep_clone = function(name, value) {
       switch(
         name,
-        optimizer = value$clone(deep = TRUE),
-        terminator = value$clone(deep = TRUE),
+        optimizer = if (!is.null(value)) value$clone(deep = TRUE) else NULL,
+        terminator = if (!is.null(value)) value$clone(deep = TRUE) else NULL,
         acq_function = if (!is.null(value)) value$clone(deep = TRUE) else NULL,
         .param_set = value$clone(deep = TRUE),
         value

--- a/R/AcqOptimizerLocalSearch.R
+++ b/R/AcqOptimizerLocalSearch.R
@@ -90,18 +90,7 @@ AcqOptimizerLocalSearch = R6Class(
   ),
 
   private = list(
-    .param_set = NULL,
-
-    deep_clone = function(name, value) {
-      switch(
-        name,
-        optimizer = value$clone(deep = TRUE),
-        terminator = value$clone(deep = TRUE),
-        acq_function = if (!is.null(value)) value$clone(deep = TRUE) else NULL,
-        .param_set = value$clone(deep = TRUE),
-        value
-      )
-    }
+    .param_set = NULL
   )
 )
 

--- a/R/AcqOptimizerRandomSearch.R
+++ b/R/AcqOptimizerRandomSearch.R
@@ -84,18 +84,7 @@ AcqOptimizerRandomSearch = R6Class(
   ),
 
   private = list(
-    .param_set = NULL,
-
-    deep_clone = function(name, value) {
-      switch(
-        name,
-        optimizer = value$clone(deep = TRUE),
-        terminator = value$clone(deep = TRUE),
-        acq_function = if (!is.null(value)) value$clone(deep = TRUE) else NULL,
-        .param_set = value$clone(deep = TRUE),
-        value
-      )
-    }
+    .param_set = NULL
   )
 )
 

--- a/tests/testthat/test_AcqFunctionMulti.R
+++ b/tests/testthat/test_AcqFunctionMulti.R
@@ -167,3 +167,25 @@ test_that("AcqFunctionMulti lazy initialization", {
   acqfs = list(AcqFunctionMean$new(surrogate_mean), AcqFunctionSD$new(surrogate_sd))
   expect_error(AcqFunctionMulti$new(acqfs), "Acquisition functions must rely on the same surrogate model")
 })
+
+test_that("AcqFunctionMulti deep cloning works", {
+  inst = MAKE_INST_1D()
+  surrogate = SurrogateLearner$new(REGR_FEATURELESS, archive = inst$archive)
+  acqfs = list(AcqFunctionMean$new(), AcqFunctionSD$new())
+  acqf = AcqFunctionMulti$new(acqfs, surrogate = surrogate)
+  design = MAKE_DESIGN(inst)
+  inst$eval_batch(design)
+  acqf$surrogate$update()
+
+  acqf_clone = acqf$clone(deep = TRUE)
+  expect_class(acqf_clone, "AcqFunctionMulti")
+  expect_false(identical(acqf, acqf_clone))
+  # acq_functions is a plain list and must be cloned element-wise
+  expect_false(identical(acqf$acq_functions[[1L]], acqf_clone$acq_functions[[1L]]))
+  # the shared-surrogate invariant asserted in $update() must survive the clone
+  expect_equal(address(acqf_clone$surrogate), address(acqf_clone$acq_functions[[1L]]$surrogate))
+  expect_equal(address(acqf_clone$surrogate), address(acqf_clone$acq_functions[[2L]]$surrogate))
+  acqf_clone$update()
+  res = acqf_clone$eval_dt(data.table(x = seq(-1, 1, length.out = 5L)))
+  expect_data_table(res, ncols = 2L, nrows = 5L, any.missing = FALSE)
+})

--- a/tests/testthat/test_AcqOptimizer.R
+++ b/tests/testthat/test_AcqOptimizer.R
@@ -172,3 +172,21 @@ test_that("AcqOptimizer callbacks", {
   res = acqopt$optimize()
   expect_number(attr(instance, "acq_opt_runtime"))
 })
+
+test_that("AcqOptimizer deep cloning works", {
+  # base class with optimizer and terminator
+  acqopt = AcqOptimizer$new(opt("random_search", batch_size = 10L), trm("evals", n_evals = 10L))
+  acqopt_clone = acqopt$clone(deep = TRUE)
+  expect_class(acqopt_clone, "AcqOptimizer")
+  expect_false(identical(acqopt$optimizer, acqopt_clone$optimizer))
+  expect_false(identical(acqopt$terminator, acqopt_clone$terminator))
+  expect_false(identical(acqopt$param_set, acqopt_clone$param_set))
+
+  # subclasses have NULL optimizer and terminator and must still deep clone
+  for (key in c("direct", "lbfgsb", "local_search", "random_search")) {
+    acqopt = acqo(key)
+    acqopt_clone = acqopt$clone(deep = TRUE)
+    expect_class(acqopt_clone, class(acqopt)[1L])
+    expect_false(identical(acqopt$param_set, acqopt_clone$param_set))
+  }
+})


### PR DESCRIPTION
## Summary

Fixes Issue 5 from the code review: `$clone(deep = TRUE)` crashed for all four `AcqOptimizer` subclasses and for `AcqFunctionMulti`.

- **`AcqOptimizer` subclasses** (`Direct`, `Lbfgsb`, `LocalSearch`, `RandomSearch`) leave the inherited `optimizer` and `terminator` fields `NULL`, so the parent `deep_clone` crashed with `attempt to apply non-function` when calling `$clone()` on `NULL`. The `optimizer`/`terminator` branches are now guarded against `NULL`, and the identical copy-pasted `deep_clone` overrides in `LocalSearch`/`RandomSearch` are removed so they inherit the fixed parent version.
- **`AcqFunctionMulti`** called `$clone()` on `.acq_functions`, which is a plain list, crashing the same way. The list is now cloned element-wise. Because cloning an `AcqFunction` shares its surrogate by reference (the established behavior for a single `AcqFunction`), the wrapped acquisition functions keep pointing to the same shared surrogate as the parent, preserving the invariant asserted in `$update()`.

## Tests

- Added a deep-clone test in `test_AcqOptimizer.R` covering the base class (independent `optimizer`/`terminator`/`param_set`) and all four subclasses.
- Added a deep-clone test in `test_AcqFunctionMulti.R` verifying the wrapped acquisition functions are cloned element-wise and continue to share one surrogate, and that `$update()`/`$eval_dt()` work on the clone.

All `AcqOptimizer` and `AcqFunctionMulti` tests pass (241 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)