### PR TITLE
fix: ResultAssignerSurrogate handles duplicated x-configurations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.
 * fix: `OptimizerADBO` and `TunerADBO` now draw the initial lambda from an exponential distribution as documented, so that the `lambda` parameter has an effect.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
+* fix: `ResultAssignerSurrogate` no longer errors when the archive contains duplicated x-configurations.
 * fix: `SurrogateLearner$predict()` no longer modifies the data.table passed as `xdt` by reference.
 
 # mlr3mbo 1.1.1

--- a/R/ResultAssignerSurrogate.R
+++ b/R/ResultAssignerSurrogate.R
@@ -70,18 +70,22 @@ ResultAssignerSurrogate = R6Class(
       }
       archive_tmp = archive$clone(deep = TRUE)
       archive_tmp$data[, self$surrogate$cols_y := means]
+      # carry a row index so that the originally evaluated ys can be recovered by position,
+      # which is robust to duplicated x-configurations (the noisy objective case)
+      archive_tmp$data[, ".result_index" := seq_len(nrow(archive_tmp$data))]
       xydt = archive_tmp$best()
       cols_x = archive_tmp$cols_x
       cols_y = archive_tmp$cols_y
+      best_index = xydt[[".result_index"]]
       best = xydt[, cols_x, with = FALSE]
-      extra = xydt[, !c(cols_x, cols_y), with = FALSE]
+      extra = xydt[, !c(cols_x, cols_y, ".result_index"), with = FALSE]
 
       # ys are still the ones originally evaluated
       if (inherits(instance, c("OptimInstanceBatchSingleCrit", "OptimInstanceAsyncSingleCrit"))) {
-        best_y = unlist(archive$data[best, on = cols_x][, cols_y, with = FALSE])
+        best_y = unlist(archive$data[best_index, cols_y, with = FALSE])
         instance$assign_result(xdt = best, y = best_y, extra = extra)
       } else if (inherits(instance, c("OptimInstanceBatchMultiCrit", "OptimInstanceAsyncMultiCrit"))) {
-        best_y = archive$data[best, on = cols_x][, cols_y, with = FALSE]
+        best_y = archive$data[best_index, cols_y, with = FALSE]
         instance$assign_result(xdt = best, ydt = best_y, extra = extra)
       }
     }

--- a/tests/testthat/test_ResultAssignerSurrogate.R
+++ b/tests/testthat/test_ResultAssignerSurrogate.R
@@ -36,6 +36,21 @@ test_that("ResultAssignerSurrogate result and best can be different", {
   expect_true(abs(instance$result[[instance$archive$cols_y]] - mean[best_index]) > 1e-2)
 })
 
+test_that("ResultAssignerSurrogate works with duplicated x-configurations", {
+  skip_if_not_installed("rpart")
+  result_assigner = ResultAssignerSurrogate$new(surrogate = SurrogateLearner$new(lrn("regr.rpart")))
+
+  instance = MAKE_INST_1D()
+  design = generate_design_grid(instance$search_space, resolution = 4L)$data
+  # duplicate every point so that the join back onto the archive by x would return multiple rows
+  instance$eval_batch(rbind(design, design))
+
+  expect_null(instance$result)
+  result_assigner$assign_result(instance)
+  expect_data_table(instance$result, nrows = 1L)
+  expect_number(instance$result[[instance$archive$cols_y]])
+})
+
 test_that("ResultAssignerSurrogate works with OptimizerMbo and bayesopt_ego", {
   skip_if_missing_regr_km()
   result_assigner = ResultAssignerSurrogate$new()


### PR DESCRIPTION
## Summary

`ResultAssignerSurrogate$assign_result()` recovered the originally-evaluated `y` values by joining the chosen best point back onto the archive by x-columns (`archive$data[best, on = cols_x]`). When the archive contains **duplicated x-configurations** — exactly the noisy-objective scenario this class is documented for, and also produced by `skip_already_evaluated = FALSE` or small discrete spaces — that join returns one row per duplicate. `best_y` then has length > 1 and bbotk aborts with `Must have length 1`. The multi-crit branch has the analogous row-count mismatch.

## Fix

Carry a temporary `.result_index` row index through the cloned archive into `$best()`, then select the original `y` values **by position** rather than by x-join. This picks exactly the row `best()` selected and is robust to duplicates. The index column is excluded from `extra`. Both the single-crit and multi-crit branches use the index.

## Test

Added a case that evaluates a grid design duplicated (so the old x-join would return multiple rows) and asserts a single-row result with a scalar `y`. All 32 `ResultAssignerSurrogate` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)