### PR TITLE
fix: guard AcqFunctionAEI noise variance against non-km models

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # mlr3mbo (development version)
 
 * fix: `AcqOptimizer` and its subclasses gained `$label` and `$man` fields, so that `as.data.table(mlr_acqoptimizers)` no longer errors.
+* fix: `AcqFunctionAEI` no longer errors during `$update()` when the surrogate model is not a `"regr.km"` model and now falls back to a noise variance of `0` as documented.
 * fix: `AcqFunctionEHVI`, `AcqFunctionEHVIGH`, and `AcqFunctionSmsEgo` now apply the surrogate's output transformation to `ys_front`, so the front and the reference point are compared on the same scale.
 * fix: `AcqFunctionEIPS` now correctly divides the expected improvement by the predicted time instead of behaving like plain expected improvement.
 * fix: `AcqFunctionMulti` can now be deep cloned without error and preserves the shared surrogate across the wrapped acquisition functions.

--- a/R/AcqFunctionAEI.R
+++ b/R/AcqFunctionAEI.R
@@ -110,12 +110,12 @@ AcqFunctionAEI = R6Class(
       y_effective = pred$mean + (self$surrogate_max_to_min * self$constants$values$c * pred$se) # pessimistic prediction
       self$y_effective_best = min(self$surrogate_max_to_min * y_effective)
 
-      if (!is.null(self$surrogate$learner$model) &&
-          length(self$surrogate$learner$model@covariance@nugget) == 1L) {
-        # FIXME: check that this value really exists (otherwise calculate residual variance?)
-        self$noise_var = self$surrogate$learner$model@covariance@nugget
+      model = self$surrogate$learner$model
+      if (!is.null(model) && inherits(model, "km") && length(model@covariance@nugget) == 1L) {
+        self$noise_var = model@covariance@nugget
       } else {
-        lgr$warn(
+        lg = lgr::get_logger("mlr3/bbotk")
+        lg$warn(
           paste0(
             'AcqFunctionAEI currently only works correctly with `"regr.km"` as surrogate ',
             "model and `nugget.estim = TRUE` or given."

--- a/tests/testthat/test_AcqFunctionAEI.R
+++ b/tests/testthat/test_AcqFunctionAEI.R
@@ -27,3 +27,19 @@ test_that("AcqFunctionAEI works", {
   expect_data_table(res, ncols = 1L, nrows = 5L, any.missing = FALSE)
   expect_named(res, "acq_aei")
 })
+
+test_that("AcqFunctionAEI falls back gracefully for non-km surrogate models", {
+  inst = MAKE_INST_1D_NOISY()
+  surrogate = SurrogateLearner$new(REGR_FEATURELESS, archive = inst$archive)
+  acqf = AcqFunctionAEI$new(surrogate = surrogate)
+
+  design = MAKE_DESIGN(inst)
+  inst$eval_batch(design)
+
+  acqf$surrogate$update()
+  # a non-km model must not error on the nugget slot access and noise_var falls back to 0
+  acqf$update()
+  expect_equal(acqf$noise_var, 0)
+  res = acqf$eval_dt(data.table(x = seq(-1, 1, length.out = 5L)))
+  expect_data_table(res, ncols = 1L, nrows = 5L, any.missing = FALSE)
+})


### PR DESCRIPTION
## Summary

Fixes review findings **R1** and **R2** for `AcqFunctionAEI` (both touch the same block in `update()`, so they are addressed together).

- **R1**: `AcqFunctionAEI$update()` accessed `model@covariance@nugget` unconditionally. On any non-S4 model (ranger, rpart, featureless) this errors *before* the documented graceful fallback (`lgr$warn(...)` + `noise_var = 0`) can run. The slot access is now guarded on the model being a `"km"` object, so non-km surrogates fall back cleanly to `noise_var = 0`.
- **R2**: the warning was emitted through the `lgr` root logger, bypassing the `mlr3/bbotk` thresholds and appenders used everywhere else in the package. It now logs via `lgr::get_logger("mlr3/bbotk")`.

## Test plan

- New test in `test_AcqFunctionAEI.R` exercises the non-km fallback path (previously this errored), asserting `noise_var == 0` and that evaluation still works.
- `devtools::load_all(); testthat::test_file("tests/testthat/test_AcqFunctionAEI.R")` → PASS 37, FAIL 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)