### PR TITLE
fix: raise informative error on domain mismatch in AcqFunctionMulti

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * fix: `AcqOptimizer` and its subclasses gained `$label` and `$man` fields, so that `as.data.table(mlr_acqoptimizers)` no longer errors.
 * fix: `AcqFunctionEHVI`, `AcqFunctionEHVIGH`, and `AcqFunctionSmsEgo` now apply the surrogate's output transformation to `ys_front`, so the front and the reference point are compared on the same scale.
 * fix: `AcqFunctionEIPS` now correctly divides the expected improvement by the predicted time instead of behaving like plain expected improvement.
+* fix: `AcqFunctionMulti` now raises an informative error when the wrapped acquisition functions do not share the same domain instead of failing with a cryptic type error.
 * fix: `AcqFunctionMulti` can now be deep cloned without error and preserves the shared surrogate across the wrapped acquisition functions.
 * fix: `AcqOptimizerDirect`, `AcqOptimizerLbfgsb`, `AcqOptimizerLocalSearch`, and `AcqOptimizerRandomSearch` can now be deep cloned without error.
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.

--- a/R/AcqFunctionMulti.R
+++ b/R/AcqFunctionMulti.R
@@ -86,7 +86,10 @@ AcqFunctionMulti = R6Class(
       )
       constants = ps()
       domains = map(acq_functions, function(acq_function) acq_function$domain)
-      assert_true(all(map_lgl(domains[-1L], function(domain) all.equal(domains[[1L]]$data, domain$data))))
+      domains_equal = map_lgl(domains[-1L], function(domain) isTRUE(all.equal(domains[[1L]]$data, domain$data)))
+      if (!all(domains_equal)) {
+        stop("All acquisition functions must have the same domain.")
+      }
       if (is.null(surrogate)) {
         surrogates = map(acq_functions, function(acq_function) acq_function$surrogate)
         assert_list(surrogates, types = c("Surrogate", "NULL"))

--- a/tests/testthat/test_AcqFunctionMulti.R
+++ b/tests/testthat/test_AcqFunctionMulti.R
@@ -168,6 +168,15 @@ test_that("AcqFunctionMulti lazy initialization", {
   expect_error(AcqFunctionMulti$new(acqfs), "Acquisition functions must rely on the same surrogate model")
 })
 
+test_that("AcqFunctionMulti errors informatively when domains differ", {
+  inst_1d = MAKE_INST_1D()
+  inst_2d = MAKE_INST(OBJ_2D, PS_2D, trm("evals", n_evals = 5L))
+  surrogate_1d = SurrogateLearner$new(REGR_FEATURELESS, archive = inst_1d$archive)
+  surrogate_2d = SurrogateLearner$new(REGR_FEATURELESS, archive = inst_2d$archive)
+  acqfs = list(AcqFunctionMean$new(surrogate_1d), AcqFunctionSD$new(surrogate_2d))
+  expect_error(AcqFunctionMulti$new(acqfs), "same domain")
+})
+
 test_that("AcqFunctionMulti deep cloning works", {
   inst = MAKE_INST_1D()
   surrogate = SurrogateLearner$new(REGR_FEATURELESS, archive = inst$archive)


### PR DESCRIPTION
## Summary

Fixes review finding **R3**.

`AcqFunctionMulti$new()` checked that all wrapped acquisition functions share the same domain via `all.equal()` inside `map_lgl()`. On a mismatch, `all.equal()` returns a character description rather than `FALSE`, so `map_lgl()` aborted with a cryptic `FUN(...) result is type 'character'` type error instead of a meaningful assertion. The comparison is now wrapped in `isTRUE()` and a clear error is raised.

## Test plan

- New test in `test_AcqFunctionMulti.R` wraps two acquisition functions with different domains and asserts the informative error.
- `devtools::load_all(); testthat::test_file("tests/testthat/test_AcqFunctionMulti.R")` → PASS 157, FAIL 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)