### PR TITLE
fix: keep tied Gauss-Hermite nodes in AcqFunctionEHVIGH pruning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * fix: `AcqOptimizer` and its subclasses gained `$label` and `$man` fields, so that `as.data.table(mlr_acqoptimizers)` no longer errors.
 * fix: `AcqFunctionEHVI`, `AcqFunctionEHVIGH`, and `AcqFunctionSmsEgo` now apply the surrogate's output transformation to `ys_front`, so the front and the reference point are compared on the same scale.
+* fix: `AcqFunctionEHVIGH` no longer prunes all Gauss-Hermite nodes when their weights are tied, which previously made the acquisition function identically `0` for `k = 2`.
 * fix: `AcqFunctionEIPS` now correctly divides the expected improvement by the predicted time instead of behaving like plain expected improvement.
 * fix: `AcqFunctionMulti` can now be deep cloned without error and preserves the shared surrogate across the wrapped acquisition functions.
 * fix: `AcqOptimizerDirect`, `AcqOptimizerLbfgsb`, `AcqOptimizerLocalSearch`, and `AcqOptimizerRandomSearch` can now be deep cloned without error.

--- a/R/AcqFunctionEHVIGH.R
+++ b/R/AcqFunctionEHVIGH.R
@@ -196,10 +196,13 @@ adjust_gh_data = function(gh_data, mu, sigma, r) {
   weights = apply(matrix(gh_data[idx, 2L], nrow = nrow(idx), ncol = n_obj), MARGIN = 1L, FUN = prod)
 
   # pruning with pruning rate r
+  # use >= so that ties at the quantile are kept; otherwise all nodes can be pruned
+  # (e.g. for k = 2 all product weights are equal, which previously made EHVIGH identically 0)
   if (r > 0) {
     weights_quantile = quantile(weights, probs = r)
-    nodes = nodes[weights > weights_quantile, ]
-    weights = weights[weights > weights_quantile]
+    keep = weights >= weights_quantile
+    nodes = nodes[keep, , drop = FALSE]
+    weights = weights[keep]
   }
 
   # rotate, scale, translate nodes with error catching

--- a/tests/testthat/test_AcqFunctionEHVIGH.R
+++ b/tests/testthat/test_AcqFunctionEHVIGH.R
@@ -34,6 +34,27 @@ test_that("AcqFunctionEHVIGH works", {
   expect_true(all(res[[acqf$id]] >= 0))
 })
 
+test_that("AcqFunctionEHVIGH does not vanish for k = 2", {
+  skip_if_not_installed("emoa")
+  skip_if_not_installed("fastGHQuad")
+  inst = MAKE_INST(OBJ_1D_2, PS_1D, trm("evals", n_evals = 5L))
+  surrogate = SurrogateLearnerCollection$new(
+    list(REGR_FEATURELESS, REGR_FEATURELESS$clone(deep = TRUE)),
+    archive = inst$archive
+  )
+  acqf = AcqFunctionEHVIGH$new(surrogate = surrogate, k = 2L)
+
+  design = MAKE_DESIGN(inst)
+  inst$eval_batch(design)
+
+  acqf$surrogate$update()
+  acqf$update()
+  res = acqf$eval_dt(data.table(x = seq(-1, 1, length.out = 5L)))
+  expect_data_table(res, ncols = 1L, nrows = 5L, any.missing = FALSE)
+  # for k = 2 all product weights are equal; strict pruning previously removed every node -> identically 0
+  expect_true(any(res[[acqf$id]] > 0))
+})
+
 test_that("AcqFunctionEHVIGH transforms ys_front onto the output trafo scale", {
   skip_if_not_installed("emoa")
   skip_if_not_installed("fastGHQuad")


### PR DESCRIPTION
## Summary

Fixes review finding **R5**.

`adjust_gh_data()` pruned Gauss-Hermite nodes with `weights > quantile(weights, r)`. On ties this drops *every* node. For `k = 2` (the minimum) all product weights are equal, so the quantile equals the common weight and the strict comparison removed all nodes, silently making `AcqFunctionEHVIGH` identically `0`. The comparison now uses `>=` so tied nodes at the quantile are kept, and indexing uses `drop = FALSE` so a single surviving node remains a matrix. With `>=`, the highest-weight node always survives, so `r = 1` can no longer prune everything.

## Test plan

- New test in `test_AcqFunctionEHVIGH.R` runs with `k = 2` and asserts the acquisition function is not identically `0`.
- `devtools::load_all()` + `testthat::test_file("tests/testthat/test_AcqFunctionEHVIGH.R")` → PASS 24, FAIL 0 (1 skip is the pre-existing `skip_on_cran` comparison test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)