### PR TITLE
fix: align AcqFunctionSmsEgo lambda bound with its constants

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * fix: `AcqOptimizer` and its subclasses gained `$label` and `$man` fields, so that `as.data.table(mlr_acqoptimizers)` no longer errors.
 * fix: `AcqFunctionEHVI`, `AcqFunctionEHVIGH`, and `AcqFunctionSmsEgo` now apply the surrogate's output transformation to `ys_front`, so the front and the reference point are compared on the same scale.
 * fix: `AcqFunctionEIPS` now correctly divides the expected improvement by the predicted time instead of behaving like plain expected improvement.
+* fix: `AcqFunctionSmsEgo` now accepts a `lambda` below `1` during construction, consistent with the lower bound of its `constants` parameter set.
 * fix: `AcqFunctionMulti` can now be deep cloned without error and preserves the shared surrogate across the wrapped acquisition functions.
 * fix: `AcqOptimizerDirect`, `AcqOptimizerLbfgsb`, `AcqOptimizerLocalSearch`, and `AcqOptimizerRandomSearch` can now be deep cloned without error.
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.

--- a/R/AcqFunctionSmsEgo.R
+++ b/R/AcqFunctionSmsEgo.R
@@ -95,7 +95,7 @@ AcqFunctionSmsEgo = R6Class(
     #' @param lambda (`numeric(1)`).
     #' @param epsilon (`NULL` | `numeric(1)`).
     initialize = function(surrogate = NULL, lambda = 1, epsilon = NULL) {
-      assert_number(lambda, lower = 1, finite = TRUE)
+      assert_number(lambda, lower = 0, finite = TRUE)
       assert_number(epsilon, lower = 0, finite = TRUE, null.ok = TRUE)
 
       constants = ps(

--- a/tests/testthat/test_AcqFunctionSmsEgo.R
+++ b/tests/testthat/test_AcqFunctionSmsEgo.R
@@ -33,6 +33,17 @@ test_that("AcqFunctionSmsEgo works", {
   expect_setequal(colnames(res), c(acqf$id, "acq_epsilon"))
 })
 
+test_that("AcqFunctionSmsEgo accepts lambda < 1 consistently with its constants", {
+  inst = MAKE_INST(OBJ_1D_2, PS_1D, trm("evals", n_evals = 5L))
+  surrogate = SurrogateLearnerCollection$new(
+    list(REGR_FEATURELESS, REGR_FEATURELESS$clone(deep = TRUE)),
+    archive = inst$archive
+  )
+  # constructor bound now matches the constants ParamSet lower bound of 0
+  acqf = AcqFunctionSmsEgo$new(surrogate = surrogate, lambda = 0.5)
+  expect_equal(acqf$constants$values$lambda, 0.5)
+})
+
 test_that("AcqFunctionSmsEgo transforms ys_front onto the output trafo scale", {
   inst = MAKE_INST(OBJ_1D_2, PS_1D, trm("evals", n_evals = 5L))
   surrogate = SurrogateLearnerCollection$new(


### PR DESCRIPTION
## Summary

Fixes review finding **R6**.

`AcqFunctionSmsEgo$new()` asserted `lambda >= 1`, but the `constants` parameter set declares `lambda = p_dbl(lower = 0, default = 1)`. As a result `$new(lambda = 0.5)` was rejected while `acqf$constants$values$lambda = 0.5` was accepted afterwards — a contradictory bound. The constructor bound is lowered to `0` to match the parameter set (and the sibling confidence-bound acquisition functions, whose `lambda` domain also starts at `0`). The `confidence = (1 - 2 * dnorm(lambda))^m` relation is valid for `lambda >= 0`.

## Test plan

- New test in `test_AcqFunctionSmsEgo.R` constructs with `lambda = 0.5` and asserts it is stored in `constants`.
- `devtools::load_all()` + `testthat::test_file("tests/testthat/test_AcqFunctionSmsEgo.R")` → PASS 23, FAIL 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)