### PR TITLE
fix: reset sampled lambda in AcqFunctionStochasticCB reset()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * fix: `AcqFunctionEHVI`, `AcqFunctionEHVIGH`, and `AcqFunctionSmsEgo` now apply the surrogate's output transformation to `ys_front`, so the front and the reference point are compared on the same scale.
 * fix: `AcqFunctionEIPS` now correctly divides the expected improvement by the predicted time instead of behaving like plain expected improvement.
 * fix: `AcqFunctionMulti` can now be deep cloned without error and preserves the shared surrogate across the wrapped acquisition functions.
+* fix: `AcqFunctionStochasticCB` now clears the sampled lambda on `$reset()`, so a reused optimizer draws a fresh initial lambda for each run as documented.
 * fix: `AcqOptimizerDirect`, `AcqOptimizerLbfgsb`, `AcqOptimizerLocalSearch`, and `AcqOptimizerRandomSearch` can now be deep cloned without error.
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.
 * fix: `OptimizerADBO` and `TunerADBO` now draw the initial lambda from an exponential distribution as documented, so that the `lambda` parameter has an effect.

--- a/R/AcqFunctionStochasticCB.R
+++ b/R/AcqFunctionStochasticCB.R
@@ -166,9 +166,11 @@ AcqFunctionStochasticCB = R6Class(
 
     #' @description
     #' Reset the acquisition function.
-    #' Resets the private update counter `.t` used within the epsilon decay.
+    #' Resets the private update counter `.t` and the sampled lambda so that a fresh lambda is drawn on the next run.
     reset = function() {
       private$.t = 0L
+      private$.lambda_0 = NULL
+      self$constants$values$lambda = NULL
     }
   ),
 

--- a/tests/testthat/test_AcqFunctionStochasticCB.R
+++ b/tests/testthat/test_AcqFunctionStochasticCB.R
@@ -1,3 +1,16 @@
+test_that("AcqFunctionStochasticCB reset draws a fresh lambda on the next run", {
+  acqf = AcqFunctionStochasticCB$new()
+  acqf$update()
+  expect_number(acqf$constants$values$lambda)
+
+  acqf$reset()
+  # the sampled lambda must be cleared so the next run resamples it
+  expect_null(acqf$constants$values$lambda)
+
+  acqf$update()
+  expect_number(acqf$constants$values$lambda)
+})
+
 skip_if_not_installed("rush")
 skip_if_no_redis()
 


### PR DESCRIPTION
## Summary

Fixes review finding **R7**.

`AcqFunctionStochasticCB$reset()` reset only the update counter `.t`, leaving the previously sampled lambda in both `constants$values$lambda` and `private$.lambda_0`. `update()` only samples a new lambda when `constants$values$lambda` is `NULL`, so a reused optimizer kept the first run's lambda forever. Because `OptimizerMbo`/`OptimizerAsyncMbo` call `$reset()` at the start of every run, this contradicted the documented behavior of drawing an initial lambda per run. `reset()` now nulls out `constants$values$lambda` and `private$.lambda_0` in addition to `.t`.

## Test plan

- New redis-independent test in `test_AcqFunctionStochasticCB.R`: `update()` samples a lambda, `reset()` clears it (`constants$values$lambda` is `NULL`), and the next `update()` resamples.
- `devtools::load_all()` + `testthat::test_file("tests/testthat/test_AcqFunctionStochasticCB.R")` → PASS 3, FAIL 0 (the async tests skip without Redis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)