### PR TITLE
fix!: remove restarts from AcqOptimizerDirect

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
 * fix: `AcqFunctionMulti` now raises an informative error when the wrapped acquisition functions do not share the same domain instead of failing with a cryptic type error.
 * fix: `AcqFunctionMulti` can now be deep cloned without error and preserves the shared surrogate across the wrapped acquisition functions.
 * fix: `AcqFunctionStochasticCB` now clears the sampled lambda on `$reset()`, so a reused optimizer draws a fresh initial lambda for each run as documented.
-* fix: `AcqOptimizerDirect` now defaults to `restart_strategy = "none"` because the deterministic `NLOPT_GN_DIRECT_L` algorithm ignores the starting point, so restarts only repeated the identical search with a smaller evaluation budget.
+* BREAKING CHANGE: `AcqOptimizerDirect` no longer supports restarts and its `restart_strategy` and `max_restarts` parameters have been removed, because the deterministic `NLOPT_GN_DIRECT_L` algorithm ignores the starting point, so restarts only repeated the identical search with a smaller evaluation budget. The `$state` field now holds the `nloptr()` result of the last optimization run directly.
 * fix: `AcqOptimizerDirect`, `AcqOptimizerLbfgsb`, `AcqOptimizerLocalSearch`, and `AcqOptimizerRandomSearch` can now be deep cloned without error.
 * fix: `AcqOptimizerDirect` and `AcqOptimizerLbfgsb` now reset their `state` at the start of each `optimize()` call and clear it on `reset()`, so the `state` no longer grows unboundedly across a Bayesian optimization loop.
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
 * fix: `AcqFunctionMulti` now raises an informative error when the wrapped acquisition functions do not share the same domain instead of failing with a cryptic type error.
 * fix: `AcqFunctionMulti` can now be deep cloned without error and preserves the shared surrogate across the wrapped acquisition functions.
 * fix: `AcqFunctionStochasticCB` now clears the sampled lambda on `$reset()`, so a reused optimizer draws a fresh initial lambda for each run as documented.
-* BREAKING CHANGE: `AcqOptimizerDirect` no longer supports restarts and its `restart_strategy` and `max_restarts` parameters have been removed, because the deterministic `NLOPT_GN_DIRECT_L` algorithm ignores the starting point, so restarts only repeated the identical search with a smaller evaluation budget. The `$state` field now holds the `nloptr()` result of the last optimization run directly.
+* BREAKING CHANGE: `AcqOptimizerDirect` no longer supports restarts and its `restart_strategy` and `max_restarts` parameters have been removed, because the deterministic `NLOPT_GN_DIRECT_L` algorithm ignores the starting point, so restarts only repeated the identical search with a smaller evaluation budget.
 * fix: `AcqOptimizerDirect`, `AcqOptimizerLbfgsb`, `AcqOptimizerLocalSearch`, and `AcqOptimizerRandomSearch` can now be deep cloned without error.
 * fix: `AcqOptimizerDirect` and `AcqOptimizerLbfgsb` now reset their `state` at the start of each `optimize()` call and clear it on `reset()`, so the `state` no longer grows unboundedly across a Bayesian optimization loop.
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * fix: `AcqFunctionEHVI`, `AcqFunctionEHVIGH`, and `AcqFunctionSmsEgo` now apply the surrogate's output transformation to `ys_front`, so the front and the reference point are compared on the same scale.
 * fix: `AcqFunctionEIPS` now correctly divides the expected improvement by the predicted time instead of behaving like plain expected improvement.
 * fix: `AcqFunctionMulti` can now be deep cloned without error and preserves the shared surrogate across the wrapped acquisition functions.
+* fix: `AcqOptimizerDirect` now defaults to `restart_strategy = "none"` because the deterministic `NLOPT_GN_DIRECT_L` algorithm ignores the starting point, so restarts only repeated the identical search with a smaller evaluation budget.
 * fix: `AcqOptimizerDirect`, `AcqOptimizerLbfgsb`, `AcqOptimizerLocalSearch`, and `AcqOptimizerRandomSearch` can now be deep cloned without error.
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.
 * fix: `OptimizerADBO` and `TunerADBO` now draw the initial lambda from an exponential distribution as documented, so that the `lambda` parameter has an effect.

--- a/R/AcqOptimizerDirect.R
+++ b/R/AcqOptimizerDirect.R
@@ -5,30 +5,13 @@
 #' @description
 #' Direct acquisition function optimizer.
 #' Calls `nloptr()` from \CRANpkg{nloptr} with the `NLOPT_GN_DIRECT_L` algorithm.
-#' In its default setting, the algorithm runs a single time for at most `100 * D^2` function evaluations,
+#' In its default setting, the algorithm runs for at most `100 * D^2` function evaluations,
 #' where `D` is the dimension of the search space.
-#' The run stops when the relative tolerance of the parameters is less than `10^-4`.
-#' `NLOPT_GN_DIRECT_L` is a deterministic global optimizer that ignores the starting point.
-#' Restarts therefore only repeat the identical search with a smaller evaluation budget and are disabled by default.
-#'
-#' @section Parameters:
-#' \describe{
-#' \item{`restart_strategy`}{`character(1)`\cr
-#'   Restart strategy.
-#'   Can be `"none"` or `"random"`.
-#'   Default is `"none"`.
-#' }
-#' \item{`max_restarts`}{`integer(1)`\cr
-#'   Maximum number of restarts.
-#'   Default is `5 * D` (Default).}
-#' }
+#' The optimization stops when the relative tolerance of the parameters is less than `10^-4`.
 #'
 #' @note
-#' If the restart strategy is `"none"`, the optimizer runs a single time and stops when one of the stopping criteria is met.
-#'
-#' If `restart_strategy` is `"random"`, the optimizer additionally restarts from random points until the budget is exhausted.
-#' Because `NLOPT_GN_DIRECT_L` is deterministic and ignores the starting point, restarts do not improve the result
-#' and only split the evaluation budget across repeated searches.
+#' `NLOPT_GN_DIRECT_L` is a deterministic global optimizer that ignores the starting point.
+#' Restarts would only repeat the identical search, so the optimizer does not support them.
 #'
 #' @section Termination Parameters:
 #' The following termination parameters can be used.
@@ -65,8 +48,8 @@ AcqOptimizerDirect = R6Class(
   "AcqOptimizerDirect",
   inherit = AcqOptimizer,
   public = list(
-    #' @field state (`list()`)\cr
-    #' List of [nloptr::nloptr()] results.
+    #' @field state ([nloptr::nloptr()] result)\cr
+    #' Result of the last optimization run.
     state = NULL,
 
     #' @description
@@ -83,8 +66,6 @@ AcqOptimizerDirect = R6Class(
         ftol_rel = p_dbl(default = 0, lower = 0, upper = Inf, special_vals = list(-1)),
         ftol_abs = p_dbl(default = 0, lower = 0, upper = Inf, special_vals = list(-1)),
         minf_max = p_dbl(default = -Inf),
-        restart_strategy = p_fct(levels = c("none", "random"), init = "none"),
-        max_restarts = p_int(lower = 0L),
         catch_errors = p_lgl(init = TRUE)
       )
       private$.param_set = param_set
@@ -97,20 +78,10 @@ AcqOptimizerDirect = R6Class(
     optimize = function() {
       self$state = NULL
       pv = self$param_set$values
-      restart_strategy = pv$restart_strategy
-      max_restarts = pv$max_restarts
       maxeval = pv$maxeval
       catch_errors = pv$catch_errors
-      pv$max_restarts = NULL
-      pv$restart_strategy = NULL
       pv$maxeval = NULL
       pv$catch_errors = NULL
-
-      if (restart_strategy == "none") {
-        max_restarts = 0L
-      } else if (restart_strategy == "random" && is.null(max_restarts)) {
-        max_restarts = 5 * self$acq_function$domain$length
-      }
 
       if (is.null(maxeval)) {
         maxeval = 100 * self$acq_function$domain$length^2
@@ -126,60 +97,36 @@ AcqOptimizerDirect = R6Class(
       constants = self$acq_function$constants$values
       direction = self$acq_function$codomain$direction
 
-      y = Inf
-      n_evals = 0L
-      n_restarts = 0L
-      while ((n_evals < maxeval || maxeval < 0) && n_restarts <= max_restarts) {
-        n_restarts = n_restarts + 1L
+      # NLOPT_GN_DIRECT_L ignores the starting point; nloptr only requires x0 to infer the dimension
+      x0 = (self$acq_function$domain$lower + self$acq_function$domain$upper) / 2
 
-        x0 = if (n_restarts == 1L) {
-          as.numeric(self$acq_function$archive$best()[, self$acq_function$domain$ids(), with = FALSE])
-        } else {
-          # random restart
-          as.numeric(generate_design_random(self$acq_function$domain, n = 1)$data)
-        }
-
-        optimize = function() {
-          invoke(
-            nloptr::nloptr,
-            eval_f = wrapper,
-            lb = self$acq_function$domain$lower,
-            ub = self$acq_function$domain$upper,
-            opts = insert_named(pv, list(algorithm = "NLOPT_GN_DIRECT_L", maxeval = maxeval - n_evals)),
-            eval_grad_f = NULL,
-            x0 = x0,
-            fun = fun,
-            constants = constants,
-            direction = direction
-          )
-        }
-
-        if (catch_errors) {
-          tryCatch(
-            {
-              res = optimize()
-            },
-            error = function(error_condition) {
-              error_acq_optimizer("Acquisition function optimization failed.", parent = error_condition)
-            }
-          )
-        } else {
-          res = optimize()
-        }
-
-        if (res$objective < y) {
-          y = res$objective
-          x = res$solution
-        }
-
-        n_evals = n_evals + res$iterations
-
-        self$state = c(self$state, set_names(list(list(model = res, start = x0)), paste0("iteration_", n_restarts)))
-
-        if (restart_strategy == "none") break
+      optimize = function() {
+        invoke(
+          nloptr::nloptr,
+          eval_f = wrapper,
+          lb = self$acq_function$domain$lower,
+          ub = self$acq_function$domain$upper,
+          opts = insert_named(pv, list(algorithm = "NLOPT_GN_DIRECT_L", maxeval = maxeval)),
+          eval_grad_f = NULL,
+          x0 = x0,
+          fun = fun,
+          constants = constants,
+          direction = direction
+        )
       }
+
+      res = if (catch_errors) {
+        tryCatch(optimize(), error = function(error_condition) {
+          error_acq_optimizer("Acquisition function optimization failed.", parent = error_condition)
+        })
+      } else {
+        optimize()
+      }
+
+      self$state = res
+
       as.data.table(as.list(set_names(
-        c(x, y * direction),
+        c(res$solution, res$objective * direction),
         c(self$acq_function$domain$ids(), self$acq_function$codomain$ids())
       )))
     },

--- a/R/AcqOptimizerDirect.R
+++ b/R/AcqOptimizerDirect.R
@@ -4,11 +4,12 @@
 #'
 #' @description
 #' Direct acquisition function optimizer.
-#' Calls `nloptr()` from \CRANpkg{nloptr}.
-#' In its default setting, the algorithm restarts `5 * D` times and runs at most for `100 * D^2` function evaluations,
+#' Calls `nloptr()` from \CRANpkg{nloptr} with the `NLOPT_GN_DIRECT_L` algorithm.
+#' In its default setting, the algorithm runs a single time for at most `100 * D^2` function evaluations,
 #' where `D` is the dimension of the search space.
-#' Each run stops when the relative tolerance of the parameters is less than `10^-4`.
-#' The first iteration starts with the best point in the archive and the next iterations start from a random point.
+#' The run stops when the relative tolerance of the parameters is less than `10^-4`.
+#' `NLOPT_GN_DIRECT_L` is a deterministic global optimizer that ignores the starting point.
+#' Restarts therefore only repeat the identical search with a smaller evaluation budget and are disabled by default.
 #'
 #' @section Parameters:
 #' \describe{
@@ -23,12 +24,11 @@
 #' }
 #'
 #' @note
-#' If the restart strategy is `"none"`, the optimizer starts with the best point in the archive.
-#' The optimization stops when one of the stopping criteria is met.
+#' If the restart strategy is `"none"`, the optimizer runs a single time and stops when one of the stopping criteria is met.
 #'
-#' If `restart_strategy` is `"random"`, the optimizer runs at least for `maxeval` iterations.
-#' The first iteration starts with the best point in the archive and stops when one of the stopping criteria is met.
-#' The next iterations start from a random point.
+#' If `restart_strategy` is `"random"`, the optimizer additionally restarts from random points until the budget is exhausted.
+#' Because `NLOPT_GN_DIRECT_L` is deterministic and ignores the starting point, restarts do not improve the result
+#' and only split the evaluation budget across repeated searches.
 #'
 #' @section Termination Parameters:
 #' The following termination parameters can be used.
@@ -83,7 +83,7 @@ AcqOptimizerDirect = R6Class(
         ftol_rel = p_dbl(default = 0, lower = 0, upper = Inf, special_vals = list(-1)),
         ftol_abs = p_dbl(default = 0, lower = 0, upper = Inf, special_vals = list(-1)),
         minf_max = p_dbl(default = -Inf),
-        restart_strategy = p_fct(levels = c("none", "random"), init = "random"),
+        restart_strategy = p_fct(levels = c("none", "random"), init = "none"),
         max_restarts = p_int(lower = 0L),
         catch_errors = p_lgl(init = TRUE)
       )

--- a/man/AcqOptimizerDirect.Rd
+++ b/man/AcqOptimizerDirect.Rd
@@ -6,33 +6,14 @@
 \description{
 Direct acquisition function optimizer.
 Calls \code{nloptr()} from \CRANpkg{nloptr} with the \code{NLOPT_GN_DIRECT_L} algorithm.
-In its default setting, the algorithm runs a single time for at most \code{100 * D^2} function evaluations,
+In its default setting, the algorithm runs for at most \code{100 * D^2} function evaluations,
 where \code{D} is the dimension of the search space.
-The run stops when the relative tolerance of the parameters is less than \code{10^-4}.
-\code{NLOPT_GN_DIRECT_L} is a deterministic global optimizer that ignores the starting point.
-Restarts therefore only repeat the identical search with a smaller evaluation budget and are disabled by default.
+The optimization stops when the relative tolerance of the parameters is less than \code{10^-4}.
 }
 \note{
-If the restart strategy is \code{"none"}, the optimizer runs a single time and stops when one of the stopping criteria is met.
-
-If \code{restart_strategy} is \code{"random"}, the optimizer additionally restarts from random points until the budget is exhausted.
-Because \code{NLOPT_GN_DIRECT_L} is deterministic and ignores the starting point, restarts do not improve the result
-and only split the evaluation budget across repeated searches.
+\code{NLOPT_GN_DIRECT_L} is a deterministic global optimizer that ignores the starting point.
+Restarts would only repeat the identical search, so the optimizer does not support them.
 }
-\section{Parameters}{
-
-\describe{
-\item{\code{restart_strategy}}{\code{character(1)}\cr
-Restart strategy.
-Can be \code{"none"} or \code{"random"}.
-Default is \code{"none"}.
-}
-\item{\code{max_restarts}}{\code{integer(1)}\cr
-Maximum number of restarts.
-Default is \code{5 * D} (Default).}
-}
-}
-
 \section{Termination Parameters}{
 
 The following termination parameters can be used.
@@ -72,8 +53,8 @@ if (requireNamespace("nloptr")) {
 \section{Public fields}{
   \if{html}{\out{<div class="r6-fields">}}
   \describe{
-    \item{\code{state}}{(\code{list()})\cr
-List of \code{\link[nloptr:nloptr]{nloptr::nloptr()}} results.}
+    \item{\code{state}}{(\code{\link[nloptr:nloptr]{nloptr::nloptr()}} result)\cr
+Result of the last optimization run.}
   }
   \if{html}{\out{</div>}}
 }

--- a/man/AcqOptimizerDirect.Rd
+++ b/man/AcqOptimizerDirect.Rd
@@ -5,19 +5,19 @@
 \title{Direct Acquisition Function Optimizer}
 \description{
 Direct acquisition function optimizer.
-Calls \code{nloptr()} from \CRANpkg{nloptr}.
-In its default setting, the algorithm restarts \code{5 * D} times and runs at most for \code{100 * D^2} function evaluations,
+Calls \code{nloptr()} from \CRANpkg{nloptr} with the \code{NLOPT_GN_DIRECT_L} algorithm.
+In its default setting, the algorithm runs a single time for at most \code{100 * D^2} function evaluations,
 where \code{D} is the dimension of the search space.
-Each run stops when the relative tolerance of the parameters is less than \code{10^-4}.
-The first iteration starts with the best point in the archive and the next iterations start from a random point.
+The run stops when the relative tolerance of the parameters is less than \code{10^-4}.
+\code{NLOPT_GN_DIRECT_L} is a deterministic global optimizer that ignores the starting point.
+Restarts therefore only repeat the identical search with a smaller evaluation budget and are disabled by default.
 }
 \note{
-If the restart strategy is \code{"none"}, the optimizer starts with the best point in the archive.
-The optimization stops when one of the stopping criteria is met.
+If the restart strategy is \code{"none"}, the optimizer runs a single time and stops when one of the stopping criteria is met.
 
-If \code{restart_strategy} is \code{"random"}, the optimizer runs at least for \code{maxeval} iterations.
-The first iteration starts with the best point in the archive and stops when one of the stopping criteria is met.
-The next iterations start from a random point.
+If \code{restart_strategy} is \code{"random"}, the optimizer additionally restarts from random points until the budget is exhausted.
+Because \code{NLOPT_GN_DIRECT_L} is deterministic and ignores the starting point, restarts do not improve the result
+and only split the evaluation budget across repeated searches.
 }
 \section{Parameters}{
 

--- a/tests/testthat/test_AcqOptimizerDirect.R
+++ b/tests/testthat/test_AcqOptimizerDirect.R
@@ -53,6 +53,11 @@ test_that("AcqOptimizerDirect works with instance", {
   expect_data_table(optimizer$optimize(instance), nrows = 1L)
 })
 
+test_that("AcqOptimizerDirect defaults to restart_strategy = 'none'", {
+  acqopt = AcqOptimizerDirect$new()
+  expect_equal(acqopt$param_set$values$restart_strategy, "none")
+})
+
 test_that("AcqOptimizerDirect works with random restart", {
   skip_if_missing_regr_km()
   instance = oi(OBJ_2D, terminator = trm("evals", n_evals = 5L))

--- a/tests/testthat/test_AcqOptimizerDirect.R
+++ b/tests/testthat/test_AcqOptimizerDirect.R
@@ -7,15 +7,13 @@ test_that("AcqOptimizerDirect works", {
   surrogate = srlrn(REGR_KM_DETERM, archive = instance$archive)
   acqfun = acqf("ei", surrogate = surrogate)
   acqopt = AcqOptimizerDirect$new(acq_function = acqfun)
-  acqopt$param_set$set_values(maxeval = 200L, restart_strategy = "none")
+  acqopt$param_set$set_values(maxeval = 200L)
   acqfun$surrogate$update()
   acqfun$update()
 
   expect_data_table(acqopt$optimize(), nrows = 1L)
-  expect_list(acqopt$state)
-  expect_names(names(acqopt$state), must.include = "iteration_1")
-  expect_class(acqopt$state$iteration_1$model, "nloptr")
-  expect_true(acqopt$state$iteration_1$model$iterations <= 200L)
+  expect_class(acqopt$state, "nloptr")
+  expect_true(acqopt$state$iterations <= 200L)
 })
 
 test_that("AcqOptimizerDirect works with 2D", {
@@ -32,10 +30,8 @@ test_that("AcqOptimizerDirect works with 2D", {
   acqfun$update()
 
   expect_data_table(acqopt$optimize(), nrows = 1L)
-  expect_list(acqopt$state)
-  expect_names(names(acqopt$state), must.include = "iteration_1")
-  expect_class(acqopt$state$iteration_1$model, "nloptr")
-  expect_true(acqopt$state$iteration_1$model$iterations <= 200L)
+  expect_class(acqopt$state, "nloptr")
+  expect_true(acqopt$state$iterations <= 200L)
 })
 
 test_that("AcqOptimizerDirect works with instance", {
@@ -53,11 +49,6 @@ test_that("AcqOptimizerDirect works with instance", {
   expect_data_table(optimizer$optimize(instance), nrows = 1L)
 })
 
-test_that("AcqOptimizerDirect defaults to restart_strategy = 'none'", {
-  acqopt = AcqOptimizerDirect$new()
-  expect_equal(acqopt$param_set$values$restart_strategy, "none")
-})
-
 test_that("AcqOptimizerDirect resets state between optimize() calls", {
   skip_if_missing_regr_km()
   instance = oi(OBJ_1D, terminator = trm("evals", n_evals = 5L))
@@ -67,33 +58,20 @@ test_that("AcqOptimizerDirect resets state between optimize() calls", {
   surrogate = srlrn(REGR_KM_DETERM, archive = instance$archive)
   acqfun = acqf("ei", surrogate = surrogate)
   acqopt = AcqOptimizerDirect$new(acq_function = acqfun)
-  acqopt$param_set$set_values(maxeval = 200L, restart_strategy = "none")
+  acqopt$param_set$set_values(maxeval = 200L)
   acqfun$surrogate$update()
   acqfun$update()
 
   acqopt$optimize()
   acqopt$optimize()
-  expect_length(acqopt$state, 1L)
+  expect_class(acqopt$state, "nloptr")
 
   acqopt$reset()
   expect_null(acqopt$state)
 })
 
-test_that("AcqOptimizerDirect works with random restart", {
-  skip_if_missing_regr_km()
-  instance = oi(OBJ_2D, terminator = trm("evals", n_evals = 5L))
-  design = generate_design_grid(instance$search_space, resolution = 4L)$data
-  instance$eval_batch(design)
-
-  surrogate = srlrn(REGR_KM_DETERM, archive = instance$archive)
-  acqfun = acqf("ei", surrogate = surrogate)
-  acqopt = AcqOptimizerDirect$new(acq_function = acqfun)
-  acqopt$param_set$set_values(maxeval = -1, ftol_rel = 1e-6, restart_strategy = "random", max_restarts = 3L)
-  acqfun$surrogate$update()
-  acqfun$update()
-
-  expect_data_table(acqopt$optimize(), nrows = 1L)
-  expect_list(acqopt$state, min.len = 4L)
-  expect_names(names(acqopt$state), must.include = c("iteration_1", "iteration_2", "iteration_3", "iteration_4"))
-  walk(acqopt$state, function(x) expect_class(x$model, "nloptr"))
+test_that("AcqOptimizerDirect has no restart parameters", {
+  acqopt = AcqOptimizerDirect$new()
+  expect_true("restart_strategy" %nin% acqopt$param_set$ids())
+  expect_true("max_restarts" %nin% acqopt$param_set$ids())
 })


### PR DESCRIPTION
## Summary

`AcqOptimizerDirect` calls `nloptr()` with the `NLOPT_GN_DIRECT_L` algorithm, which is a **deterministic** global optimizer that ignores the starting point (`x0`). Restarts therefore only re-ran the *identical* search, splitting the evaluation budget across repeated runs with no benefit. Instead of merely changing the default, this PR removes the restart machinery entirely.

## Changes

- Remove the `restart_strategy` and `max_restarts` parameters and the restart loop; `optimize()` now runs a single `nloptr()` call with the full `maxeval` budget.
- `$state` now holds the `nloptr()` result of the last run directly instead of a list of per-restart entries.
- `x0` is set to the domain midpoint, since `NLOPT_GN_DIRECT_L` only uses it to infer the problem dimension.
- Correct the description and add a `@note` explaining why restarts are not supported.
- Adapt the tests and add a test asserting the restart parameters are gone.

## Breaking change

The `restart_strategy` and `max_restarts` parameters of `AcqOptimizerDirect` have been removed, and the `$state` field changed its structure.

Addresses review finding **R8**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)