### PR TITLE
fix: reset AcqOptimizerDirect/Lbfgsb state each optimize() call

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * fix: `AcqFunctionEIPS` now correctly divides the expected improvement by the predicted time instead of behaving like plain expected improvement.
 * fix: `AcqFunctionMulti` can now be deep cloned without error and preserves the shared surrogate across the wrapped acquisition functions.
 * fix: `AcqOptimizerDirect`, `AcqOptimizerLbfgsb`, `AcqOptimizerLocalSearch`, and `AcqOptimizerRandomSearch` can now be deep cloned without error.
+* fix: `AcqOptimizerDirect` and `AcqOptimizerLbfgsb` now reset their `state` at the start of each `optimize()` call and clear it on `reset()`, so the `state` no longer grows unboundedly across a Bayesian optimization loop.
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.
 * fix: `OptimizerADBO` and `TunerADBO` now draw the initial lambda from an exponential distribution as documented, so that the `lambda` parameter has an effect.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.

--- a/R/AcqOptimizerDirect.R
+++ b/R/AcqOptimizerDirect.R
@@ -95,6 +95,7 @@ AcqOptimizerDirect = R6Class(
     #'
     #' @return [data.table::data.table()] with 1 row per candidate.
     optimize = function() {
+      self$state = NULL
       pv = self$param_set$values
       restart_strategy = pv$restart_strategy
       max_restarts = pv$max_restarts
@@ -181,6 +182,14 @@ AcqOptimizerDirect = R6Class(
         c(x, y * direction),
         c(self$acq_function$domain$ids(), self$acq_function$codomain$ids())
       )))
+    },
+
+    #' @description
+    #' Reset the acquisition function optimizer.
+    #'
+    #' Clears the `state` of the previous optimization run.
+    reset = function() {
+      self$state = NULL
     }
   ),
 

--- a/R/AcqOptimizerLbfgsb.R
+++ b/R/AcqOptimizerLbfgsb.R
@@ -95,6 +95,7 @@ AcqOptimizerLbfgsb = R6Class(
     #'
     #' @return [data.table::data.table()] with 1 row per candidate.
     optimize = function() {
+      self$state = NULL
       pv = self$param_set$values
       restart_strategy = pv$restart_strategy
       max_restarts = pv$max_restarts
@@ -201,6 +202,14 @@ AcqOptimizerLbfgsb = R6Class(
         c(x, y * direction),
         c(self$acq_function$domain$ids(), self$acq_function$codomain$ids())
       )))
+    },
+
+    #' @description
+    #' Reset the acquisition function optimizer.
+    #'
+    #' Clears the `state` of the previous optimization run.
+    reset = function() {
+      self$state = NULL
     }
   ),
 

--- a/man/AcqOptimizerDirect.Rd
+++ b/man/AcqOptimizerDirect.Rd
@@ -97,6 +97,7 @@ String in the format \verb{[pkg]::[topic]} pointing to a manual page for this ob
   \itemize{
     \item \href{#method-AcqOptimizerDirect-initialize}{\code{AcqOptimizerDirect$new()}}
     \item \href{#method-AcqOptimizerDirect-optimize}{\code{AcqOptimizerDirect$optimize()}}
+    \item \href{#method-AcqOptimizerDirect-reset}{\code{AcqOptimizerDirect$reset()}}
     \item \href{#method-AcqOptimizerDirect-clone}{\code{AcqOptimizerDirect$clone()}}
   }
 }
@@ -104,7 +105,6 @@ String in the format \verb{[pkg]::[topic]} pointing to a manual page for this ob
 <ul>
   <li><span class="pkg-link" data-pkg="mlr3mbo" data-topic="AcqOptimizer" data-id="format"><a href='../../mlr3mbo/html/AcqOptimizer.html#method-AcqOptimizer-format'><code>AcqOptimizer$format()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="mlr3mbo" data-topic="AcqOptimizer" data-id="print"><a href='../../mlr3mbo/html/AcqOptimizer.html#method-AcqOptimizer-print'><code>AcqOptimizer$print()</code></a></span></li>
-  <li><span class="pkg-link" data-pkg="mlr3mbo" data-topic="AcqOptimizer" data-id="reset"><a href='../../mlr3mbo/html/AcqOptimizer.html#method-AcqOptimizer-reset'><code>AcqOptimizer$reset()</code></a></span></li>
 </ul>
 </details>}}
 \if{html}{\out{<hr>}}
@@ -138,6 +138,20 @@ String in the format \verb{[pkg]::[topic]} pointing to a manual page for this ob
   }
   \subsection{Returns}{
     \code{\link[data.table:data.table]{data.table::data.table()}} with 1 row per candidate.
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-AcqOptimizerDirect-reset"></a>}}
+\if{latex}{\out{\hypertarget{method-AcqOptimizerDirect-reset}{}}}
+\subsection{\code{AcqOptimizerDirect$reset()}}{
+  Reset the acquisition function optimizer.
+
+Clears the \code{state} of the previous optimization run.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{AcqOptimizerDirect$reset()}
+    \if{html}{\out{</div>}}
   }
 }
 

--- a/man/AcqOptimizerLbfgsb.Rd
+++ b/man/AcqOptimizerLbfgsb.Rd
@@ -97,6 +97,7 @@ String in the format \verb{[pkg]::[topic]} pointing to a manual page for this ob
   \itemize{
     \item \href{#method-AcqOptimizerLbfgsb-initialize}{\code{AcqOptimizerLbfgsb$new()}}
     \item \href{#method-AcqOptimizerLbfgsb-optimize}{\code{AcqOptimizerLbfgsb$optimize()}}
+    \item \href{#method-AcqOptimizerLbfgsb-reset}{\code{AcqOptimizerLbfgsb$reset()}}
     \item \href{#method-AcqOptimizerLbfgsb-clone}{\code{AcqOptimizerLbfgsb$clone()}}
   }
 }
@@ -104,7 +105,6 @@ String in the format \verb{[pkg]::[topic]} pointing to a manual page for this ob
 <ul>
   <li><span class="pkg-link" data-pkg="mlr3mbo" data-topic="AcqOptimizer" data-id="format"><a href='../../mlr3mbo/html/AcqOptimizer.html#method-AcqOptimizer-format'><code>AcqOptimizer$format()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="mlr3mbo" data-topic="AcqOptimizer" data-id="print"><a href='../../mlr3mbo/html/AcqOptimizer.html#method-AcqOptimizer-print'><code>AcqOptimizer$print()</code></a></span></li>
-  <li><span class="pkg-link" data-pkg="mlr3mbo" data-topic="AcqOptimizer" data-id="reset"><a href='../../mlr3mbo/html/AcqOptimizer.html#method-AcqOptimizer-reset'><code>AcqOptimizer$reset()</code></a></span></li>
 </ul>
 </details>}}
 \if{html}{\out{<hr>}}
@@ -138,6 +138,20 @@ String in the format \verb{[pkg]::[topic]} pointing to a manual page for this ob
   }
   \subsection{Returns}{
     \code{\link[data.table:data.table]{data.table::data.table()}} with 1 row per candidate.
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-AcqOptimizerLbfgsb-reset"></a>}}
+\if{latex}{\out{\hypertarget{method-AcqOptimizerLbfgsb-reset}{}}}
+\subsection{\code{AcqOptimizerLbfgsb$reset()}}{
+  Reset the acquisition function optimizer.
+
+Clears the \code{state} of the previous optimization run.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{AcqOptimizerLbfgsb$reset()}
+    \if{html}{\out{</div>}}
   }
 }
 

--- a/tests/testthat/test_AcqOptimizerDirect.R
+++ b/tests/testthat/test_AcqOptimizerDirect.R
@@ -53,6 +53,27 @@ test_that("AcqOptimizerDirect works with instance", {
   expect_data_table(optimizer$optimize(instance), nrows = 1L)
 })
 
+test_that("AcqOptimizerDirect resets state between optimize() calls", {
+  skip_if_missing_regr_km()
+  instance = oi(OBJ_1D, terminator = trm("evals", n_evals = 5L))
+  design = generate_design_grid(instance$search_space, resolution = 4L)$data
+  instance$eval_batch(design)
+
+  surrogate = srlrn(REGR_KM_DETERM, archive = instance$archive)
+  acqfun = acqf("ei", surrogate = surrogate)
+  acqopt = AcqOptimizerDirect$new(acq_function = acqfun)
+  acqopt$param_set$set_values(maxeval = 200L, restart_strategy = "none")
+  acqfun$surrogate$update()
+  acqfun$update()
+
+  acqopt$optimize()
+  acqopt$optimize()
+  expect_length(acqopt$state, 1L)
+
+  acqopt$reset()
+  expect_null(acqopt$state)
+})
+
 test_that("AcqOptimizerDirect works with random restart", {
   skip_if_missing_regr_km()
   instance = oi(OBJ_2D, terminator = trm("evals", n_evals = 5L))

--- a/tests/testthat/test_AcqOptimizerLbfgsb.R
+++ b/tests/testthat/test_AcqOptimizerLbfgsb.R
@@ -18,6 +18,27 @@ test_that("AcqOptimizerLbfgsb works", {
   expect_true(acqopt$state$iteration_1$model$iterations <= 200L)
 })
 
+test_that("AcqOptimizerLbfgsb resets state between optimize() calls", {
+  skip_if_missing_regr_km()
+  instance = oi(OBJ_1D, terminator = trm("evals", n_evals = 5L))
+  design = generate_design_grid(instance$search_space, resolution = 4L)$data
+  instance$eval_batch(design)
+
+  surrogate = srlrn(REGR_KM_DETERM, archive = instance$archive)
+  acqfun = acqf("ei", surrogate = surrogate)
+  acqopt = AcqOptimizerLbfgsb$new(acq_function = acqfun)
+  acqopt$param_set$set_values(maxeval = 200L, restart_strategy = "none")
+  acqfun$surrogate$update()
+  acqfun$update()
+
+  acqopt$optimize()
+  acqopt$optimize()
+  expect_length(acqopt$state, 1L)
+
+  acqopt$reset()
+  expect_null(acqopt$state)
+})
+
 test_that("AcqOptimizerLbfgsb works with 2D", {
   skip_if_missing_regr_km()
   instance = oi(OBJ_2D, terminator = trm("evals", n_evals = 5L))


### PR DESCRIPTION
## Summary

`AcqOptimizerDirect` and `AcqOptimizerLbfgsb` appended their per-run `nloptr` results to `self$state` with names `iteration_1`, `iteration_2`, ... but never cleared `state` between calls. Across a Bayesian optimization loop `state` grew unboundedly and accumulated duplicate `iteration_1` names. The inherited `reset()` was a no-op and did not clear it either.

## Changes

- Reset `self$state = NULL` at the top of `optimize()` in both optimizers.
- Override `reset()` in both optimizers to clear `state`.
- Add tests asserting `state` holds only the last run and that `reset()` clears it.

Addresses review finding **R9**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)