### PR TITLE
fix: respect warmstart_size for multi-crit archives in AcqOptimizer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # mlr3mbo (development version)
 
+* fix: `AcqOptimizer` now respects `warmstart_size` when warm-starting a single-objective acquisition function on a multi-objective archive, instead of evaluating the entire non-dominated front.
 * fix: `AcqOptimizer` and its subclasses gained `$label` and `$man` fields, so that `as.data.table(mlr_acqoptimizers)` no longer errors.
 * fix: `AcqFunctionEHVI`, `AcqFunctionEHVIGH`, and `AcqFunctionSmsEgo` now apply the surrogate's output transformation to `ys_front`, so the front and the reference point are compared on the same scale.
 * fix: `AcqFunctionEIPS` now correctly divides the expected improvement by the predicted time instead of behaving like plain expected improvement.

--- a/R/AcqOptimizer.R
+++ b/R/AcqOptimizer.R
@@ -195,7 +195,11 @@ AcqOptimizer = R6Class(
           self$param_set$values$warmstart_size %??% 1L
         } # default is 1L
         n_select = min(nrow(self$acq_function$archive$data), warmstart_size)
-        warmstart_xdt = if (is_multi_acq_function) {
+        # branch on the codomain of the actual instance archive, not on the acq codomain:
+        # a single-objective acq function (e.g., SMS-EGO, EHVI, ParEGO) can wrap a multi-crit archive whose
+        # best() would return the entire non-dominated front and ignore warmstart_size
+        is_multi_crit_archive = length(self$acq_function$archive$cols_y) > 1L
+        warmstart_xdt = if (is_multi_crit_archive) {
           self$acq_function$archive$nds_selection(n_select = n_select)[, instance$search_space$ids(), with = FALSE]
         } else {
           self$acq_function$archive$best(n_select = n_select)[, instance$search_space$ids(), with = FALSE]

--- a/tests/testthat/test_AcqOptimizer.R
+++ b/tests/testthat/test_AcqOptimizer.R
@@ -173,6 +173,35 @@ test_that("AcqOptimizer callbacks", {
   expect_number(attr(instance, "acq_opt_runtime"))
 })
 
+test_that("AcqOptimizer warmstart respects warmstart_size for multi-crit archives", {
+  instance = MAKE_INST(objective = OBJ_1D_2, search_space = PS_1D, terminator = trm("evals", n_evals = 20L))
+  instance$eval_batch(data.table(x = seq(-1, 1, length.out = 8L)))
+  surrogate = srlrn(list(lrn("regr.featureless"), lrn("regr.featureless")), archive = instance$archive)
+  acqfun = acqf("smsego", surrogate = surrogate)
+  acqfun$surrogate$update()
+  acqfun$progress = 1
+  acqfun$update()
+
+  # the non-dominated front has more than one point, so best() would ignore warmstart_size
+  expect_gt(nrow(instance$archive$best()), 1L)
+
+  callback = callback_batch("mlr3mbo.warmstart_count",
+    on_optimization_begin = function(callback, context) {
+      attr(callback$state$outer, "n_warmstart") = context$instance$archive$n_evals
+    }
+  )
+  acqopt = AcqOptimizer$new(
+    opt("random_search", batch_size = 20L),
+    trm("evals", n_evals = 20L),
+    acq_function = acqfun,
+    callbacks = callback
+  )
+  callback$state$outer = acqopt
+  acqopt$param_set$set_values(warmstart = TRUE, warmstart_size = 1L)
+  acqopt$optimize()
+  expect_equal(attr(acqopt, "n_warmstart"), 1L)
+})
+
 test_that("AcqOptimizer deep cloning works", {
   # base class with optimizer and terminator
   acqopt = AcqOptimizer$new(opt("random_search", batch_size = 10L), trm("evals", n_evals = 10L))


### PR DESCRIPTION
## Summary

`AcqOptimizer`'s warmstart branch keyed on the acquisition function codomain (`is_multi_acq_function`). A single-objective acquisition function that wraps a *multi-objective* archive (SMS-EGO, EHVI, ParEGO) therefore fell into the `best()` path. `ArchiveBatch$best()` on a multi-crit archive returns the **entire non-dominated front** and ignores `n_select`, so `warmstart_size` was silently ignored and an arbitrary chunk of the acquisition budget was consumed.

## Changes

- Branch on the codomain of the actual instance archive (`length(cols_y) > 1`) and use `nds_selection(n_select)` for a multi-objective archive.
- Add a test (multi-crit instance + SMS-EGO) asserting that `warmstart_size = 1` warm-starts exactly one point even though the non-dominated front has several.

Addresses review finding **R12**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)