### PR TITLE
fix: rebuild x_domain after clipping candidates to bounds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # mlr3mbo (development version)
 
+* fix: `AcqOptimizer` now rebuilds the `x_domain` column after clipping candidates to the search space bounds, so a stale out-of-bounds `x_domain` is no longer stored in the archive.
 * fix: `AcqOptimizer` and its subclasses gained `$label` and `$man` fields, so that `as.data.table(mlr_acqoptimizers)` no longer errors.
 * fix: `AcqFunctionEHVI`, `AcqFunctionEHVIGH`, and `AcqFunctionSmsEgo` now apply the surrogate's output transformation to `ys_front`, so the front and the reference point are compared on the same scale.
 * fix: `AcqFunctionEIPS` now correctly divides the expected improvement by the predicted time instead of behaving like plain expected improvement.

--- a/R/AcqOptimizer.R
+++ b/R/AcqOptimizer.R
@@ -261,12 +261,21 @@ AcqOptimizer = R6Class(
       }
       # the following is required to assure that evaluations of numerical gradient based methods that potentially
       # evaluated out of bounds are not returned as out of bound but clipped to bounds
+      clipped = FALSE
       for (param in names(which(instance$search_space$is_number))) {
-        set(
-          xdt,
-          j = param,
-          value = pmax(pmin(xdt[[param]], instance$search_space$upper[[param]]), instance$search_space$lower[[param]])
+        clipped_value = pmax(
+          pmin(xdt[[param]], instance$search_space$upper[[param]]),
+          instance$search_space$lower[[param]]
         )
+        if (!isTRUE(all.equal(clipped_value, xdt[[param]]))) {
+          clipped = TRUE
+        }
+        set(xdt, j = param, value = clipped_value)
+      }
+      # rebuild the stale x_domain list column from the clipped x columns, otherwise the out-of-bounds x_domain
+      # would be stored verbatim in the real archive and break the x == x_domain invariant
+      if (clipped && "x_domain" %in% names(xdt)) {
+        set(xdt, j = "x_domain", value = transform_xdt_to_xss(xdt, instance$search_space))
       }
       #if (is_multi_acq_function) {
       #  set(xdt, j = instance$objective$id,

--- a/R/AcqOptimizer.R
+++ b/R/AcqOptimizer.R
@@ -267,7 +267,7 @@ AcqOptimizer = R6Class(
           pmin(xdt[[param]], instance$search_space$upper[[param]]),
           instance$search_space$lower[[param]]
         )
-        if (!isTRUE(all.equal(clipped_value, xdt[[param]]))) {
+        if (!clipped && any(clipped_value != xdt[[param]])) {
           clipped = TRUE
         }
         set(xdt, j = param, value = clipped_value)

--- a/tests/testthat/test_AcqOptimizer.R
+++ b/tests/testthat/test_AcqOptimizer.R
@@ -173,6 +173,26 @@ test_that("AcqOptimizer callbacks", {
   expect_number(attr(instance, "acq_opt_runtime"))
 })
 
+test_that("AcqOptimizer rebuilds x_domain after clipping to bounds", {
+  OptimizerOOB = R6::R6Class("OptimizerOOB", inherit = OptimizerBatch,
+    public = list(initialize = function() super$initialize(param_set = ps(),
+      param_classes = "ParamDbl", properties = "single-crit")),
+    private = list(.optimize = function(inst) inst$eval_batch(data.table(x = 2)))
+  )
+  instance = MAKE_INST_1D(terminator = trm("evals", n_evals = 10L))
+  instance$eval_batch(data.table(x = c(-0.5, 0, 0.5)))
+  surrogate = srlrn(REGR_FEATURELESS, archive = instance$archive)
+  acqfun = acqf("mean", surrogate = surrogate)
+  acqfun$surrogate$update()
+  acqfun$update()
+  acqopt = AcqOptimizer$new(OptimizerOOB$new(), trm("evals", n_evals = 1L), acq_function = acqfun)
+  xdt = acqopt$optimize()
+
+  # out-of-bounds candidate x = 2 is clipped to the upper bound and x_domain follows
+  expect_equal(xdt$x, 1)
+  expect_equal(unname(unlist(xdt$x_domain[[1L]])), 1)
+})
+
 test_that("AcqOptimizer deep cloning works", {
   # base class with optimizer and terminator
   acqopt = AcqOptimizer$new(opt("random_search", batch_size = 10L), trm("evals", n_evals = 10L))


### PR DESCRIPTION
## Summary

`AcqOptimizer$optimize()` clips numeric candidate columns back into the search space bounds (numerical gradient based optimizers can evaluate slightly out of bounds), but it left the `x_domain` list column untouched. bbotk's fast path stores the provided `x_domain` verbatim in the real archive, so a stale, out-of-bounds `x_domain` was persisted, breaking the `x == x_domain` invariant.

## Changes

- Track whether clipping actually changed any value and, if so, rebuild `x_domain` from the clipped x columns via `bbotk::transform_xdt_to_xss()`.
- Add a test using a custom optimizer that proposes an out-of-bounds candidate and asserts the returned `x_domain` matches the clipped x.

Addresses review finding **R13**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)