### PR TITLE
fix: accept maxeval = -1L in nloptr acq optimizers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * fix: `AcqFunctionEIPS` now correctly divides the expected improvement by the predicted time instead of behaving like plain expected improvement.
 * fix: `AcqFunctionMulti` can now be deep cloned without error and preserves the shared surrogate across the wrapped acquisition functions.
 * fix: `AcqOptimizerDirect`, `AcqOptimizerLbfgsb`, `AcqOptimizerLocalSearch`, and `AcqOptimizerRandomSearch` can now be deep cloned without error.
+* fix: `AcqOptimizerDirect` and `AcqOptimizerLbfgsb` now accept `maxeval = -1L` to deactivate the evaluation limit, as documented.
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.
 * fix: `OptimizerADBO` and `TunerADBO` now draw the initial lambda from an exponential distribution as documented, so that the `lambda` parameter has an effect.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.

--- a/R/AcqOptimizerDirect.R
+++ b/R/AcqOptimizerDirect.R
@@ -76,7 +76,7 @@ AcqOptimizerDirect = R6Class(
     initialize = function(acq_function = NULL) {
       self$acq_function = assert_r6(acq_function, "AcqFunction", null.ok = TRUE)
       param_set = ps(
-        maxeval = p_int(lower = 1, special_vals = list(-1)),
+        maxeval = p_int(lower = 1, special_vals = list(-1L, -1)),
         stopval = p_dbl(default = -Inf, lower = -Inf, upper = Inf),
         xtol_rel = p_dbl(default = 1e-04, lower = 0, upper = Inf, special_vals = list(-1)),
         xtol_abs = p_dbl(default = 0, lower = 0, upper = Inf, special_vals = list(-1)),

--- a/R/AcqOptimizerLbfgsb.R
+++ b/R/AcqOptimizerLbfgsb.R
@@ -76,7 +76,7 @@ AcqOptimizerLbfgsb = R6Class(
     initialize = function(acq_function = NULL) {
       self$acq_function = assert_r6(acq_function, "AcqFunction", null.ok = TRUE)
       param_set = ps(
-        maxeval = p_int(lower = 1, special_vals = list(-1)),
+        maxeval = p_int(lower = 1, special_vals = list(-1L, -1)),
         stopval = p_dbl(default = -Inf, lower = -Inf, upper = Inf),
         xtol_rel = p_dbl(default = 1e-04, lower = 0, upper = Inf, special_vals = list(-1)),
         xtol_abs = p_dbl(default = 0, lower = 0, upper = Inf, special_vals = list(-1)),

--- a/tests/testthat/test_AcqOptimizerDirect.R
+++ b/tests/testthat/test_AcqOptimizerDirect.R
@@ -53,6 +53,12 @@ test_that("AcqOptimizerDirect works with instance", {
   expect_data_table(optimizer$optimize(instance), nrows = 1L)
 })
 
+test_that("AcqOptimizerDirect maxeval accepts -1L and -1 to deactivate", {
+  acqopt = AcqOptimizerDirect$new()
+  expect_error(acqopt$param_set$set_values(maxeval = -1L), NA)
+  expect_error(acqopt$param_set$set_values(maxeval = -1), NA)
+})
+
 test_that("AcqOptimizerDirect works with random restart", {
   skip_if_missing_regr_km()
   instance = oi(OBJ_2D, terminator = trm("evals", n_evals = 5L))

--- a/tests/testthat/test_AcqOptimizerLbfgsb.R
+++ b/tests/testthat/test_AcqOptimizerLbfgsb.R
@@ -18,6 +18,12 @@ test_that("AcqOptimizerLbfgsb works", {
   expect_true(acqopt$state$iteration_1$model$iterations <= 200L)
 })
 
+test_that("AcqOptimizerLbfgsb maxeval accepts -1L and -1 to deactivate", {
+  acqopt = AcqOptimizerLbfgsb$new()
+  expect_error(acqopt$param_set$set_values(maxeval = -1L), NA)
+  expect_error(acqopt$param_set$set_values(maxeval = -1), NA)
+})
+
 test_that("AcqOptimizerLbfgsb works with 2D", {
   skip_if_missing_regr_km()
   instance = oi(OBJ_2D, terminator = trm("evals", n_evals = 5L))


### PR DESCRIPTION
## Summary

`AcqOptimizerDirect` and `AcqOptimizerLbfgsb` document that the `maxeval` termination parameter can be deactivated with `-1L`, but the parameter was defined with `special_vals = list(-1)`. Special values are matched with `identical()`, and `identical(-1L, -1)` is `FALSE`, so `set_values(maxeval = -1L)` was rejected with `Element 1 is not >= 0.5`.

## Changes

- Use `special_vals = list(-1L, -1)` in both optimizers so both the documented integer `-1L` and the double `-1` are accepted.
- Add tests for both.

Addresses review finding **R14**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)