### PR TITLE
fix: remove dead minf_max parameter from nloptr acq optimizers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * fix: `AcqFunctionEIPS` now correctly divides the expected improvement by the predicted time instead of behaving like plain expected improvement.
 * fix: `AcqFunctionMulti` can now be deep cloned without error and preserves the shared surrogate across the wrapped acquisition functions.
 * fix: `AcqOptimizerDirect`, `AcqOptimizerLbfgsb`, `AcqOptimizerLocalSearch`, and `AcqOptimizerRandomSearch` can now be deep cloned without error.
+* fix: `AcqOptimizerDirect` and `AcqOptimizerLbfgsb` no longer expose the `minf_max` parameter, which was not a valid `nloptr` option and was silently ignored.
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.
 * fix: `OptimizerADBO` and `TunerADBO` now draw the initial lambda from an exponential distribution as documented, so that the `lambda` parameter has an effect.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.

--- a/R/AcqOptimizerDirect.R
+++ b/R/AcqOptimizerDirect.R
@@ -82,7 +82,6 @@ AcqOptimizerDirect = R6Class(
         xtol_abs = p_dbl(default = 0, lower = 0, upper = Inf, special_vals = list(-1)),
         ftol_rel = p_dbl(default = 0, lower = 0, upper = Inf, special_vals = list(-1)),
         ftol_abs = p_dbl(default = 0, lower = 0, upper = Inf, special_vals = list(-1)),
-        minf_max = p_dbl(default = -Inf),
         restart_strategy = p_fct(levels = c("none", "random"), init = "random"),
         max_restarts = p_int(lower = 0L),
         catch_errors = p_lgl(init = TRUE)

--- a/R/AcqOptimizerLbfgsb.R
+++ b/R/AcqOptimizerLbfgsb.R
@@ -82,7 +82,6 @@ AcqOptimizerLbfgsb = R6Class(
         xtol_abs = p_dbl(default = 0, lower = 0, upper = Inf, special_vals = list(-1)),
         ftol_rel = p_dbl(default = 0, lower = 0, upper = Inf, special_vals = list(-1)),
         ftol_abs = p_dbl(default = 0, lower = 0, upper = Inf, special_vals = list(-1)),
-        minf_max = p_dbl(default = -Inf),
         restart_strategy = p_fct(levels = c("none", "random"), init = "none"),
         max_restarts = p_int(lower = 0L),
         catch_errors = p_lgl(init = TRUE)

--- a/tests/testthat/test_AcqOptimizerDirect.R
+++ b/tests/testthat/test_AcqOptimizerDirect.R
@@ -53,6 +53,10 @@ test_that("AcqOptimizerDirect works with instance", {
   expect_data_table(optimizer$optimize(instance), nrows = 1L)
 })
 
+test_that("AcqOptimizerDirect does not expose the dead minf_max parameter", {
+  expect_false("minf_max" %in% AcqOptimizerDirect$new()$param_set$ids())
+})
+
 test_that("AcqOptimizerDirect works with random restart", {
   skip_if_missing_regr_km()
   instance = oi(OBJ_2D, terminator = trm("evals", n_evals = 5L))

--- a/tests/testthat/test_AcqOptimizerLbfgsb.R
+++ b/tests/testthat/test_AcqOptimizerLbfgsb.R
@@ -18,6 +18,10 @@ test_that("AcqOptimizerLbfgsb works", {
   expect_true(acqopt$state$iteration_1$model$iterations <= 200L)
 })
 
+test_that("AcqOptimizerLbfgsb does not expose the dead minf_max parameter", {
+  expect_false("minf_max" %in% AcqOptimizerLbfgsb$new()$param_set$ids())
+})
+
 test_that("AcqOptimizerLbfgsb works with 2D", {
   skip_if_missing_regr_km()
   instance = oi(OBJ_2D, terminator = trm("evals", n_evals = 5L))


### PR DESCRIPTION
## Summary

`AcqOptimizerDirect` and `AcqOptimizerLbfgsb` defined a `minf_max` parameter that was passed to `nloptr()` via the `opts` list. `minf_max` is not a recognized `nloptr` option (the corresponding option is `stopval`, which is already defined one line above), so it was silently ignored — a dead parameter.

## Changes

- Remove the `minf_max` parameter from both optimizers' parameter sets.
- Add tests asserting the parameter is gone.

Addresses review finding **R15**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)