### PR TITLE
docs: fix restart documentation drift in nloptr acq optimizers

### DIFF
--- a/R/AcqOptimizerDirect.R
+++ b/R/AcqOptimizerDirect.R
@@ -19,14 +19,14 @@
 #' }
 #' \item{`max_restarts`}{`integer(1)`\cr
 #'   Maximum number of restarts.
-#'   Default is `5 * D` (Default).}
+#'   Default is `5 * D`, where `D` is the dimension of the search space.}
 #' }
 #'
 #' @note
 #' If the restart strategy is `"none"`, the optimizer starts with the best point in the archive.
 #' The optimization stops when one of the stopping criteria is met.
 #'
-#' If `restart_strategy` is `"random"`, the optimizer runs at least for `maxeval` iterations.
+#' If `restart_strategy` is `"random"`, the optimizer runs at most for `maxeval` iterations in total.
 #' The first iteration starts with the best point in the archive and stops when one of the stopping criteria is met.
 #' The next iterations start from a random point.
 #'
@@ -50,7 +50,7 @@
 #'   Deactivate with `-1` (Default).}
 #' \item{`ftol_rel`}{`numeric(1)`\cr
 #'   Relative tolerance of the objective function.
-#'   Deactivate with `-1`. (Default).}
+#'   Deactivate with `-1` (Default).}
 #' \item{`ftol_abs`}{`numeric(1)`\cr
 #'   Absolute tolerance of the objective function.
 #'   Deactivate with `-1` (Default).}

--- a/R/AcqOptimizerLbfgsb.R
+++ b/R/AcqOptimizerLbfgsb.R
@@ -4,11 +4,12 @@
 #'
 #' @description
 #' L-BFGS-B acquisition function optimizer.
-#' Calls `nloptr()` from \CRANpkg{nloptr}.
-#' In its default setting, the algorithm restarts `5 * D` times and runs at most for `100 * D^2` function evaluations,
-#' where `D` is the dimension of the search space.
-#' Each run stops when the relative tolerance of the parameters is less than `10^-4`.
-#' The first iteration starts with the best point in the archive and the next iterations start from a random point.
+#' Calls `nloptr()` from \CRANpkg{nloptr} with the `NLOPT_LD_LBFGS` algorithm.
+#' In its default setting, the algorithm runs a single time starting from the best point in the archive,
+#' for at most `100 * D^2` function evaluations, where `D` is the dimension of the search space.
+#' The run stops when the relative tolerance of the parameters is less than `10^-4`.
+#' With `restart_strategy = "random"`, the optimizer additionally restarts from random points until the evaluation
+#' budget is exhausted, which can help escape local optima.
 #'
 #' @section Parameters:
 #' \describe{
@@ -19,14 +20,14 @@
 #' }
 #' \item{`max_restarts`}{`integer(1)`\cr
 #'   Maximum number of restarts.
-#'   Default is `5 * D` (Default).}
+#'   Default is `5 * D`, where `D` is the dimension of the search space.}
 #' }
 #'
 #' @note
-#' If the restart strategy is `"none"`, the optimizer starts with the best point in the archive.
+#' If the restart strategy is `"none"`, the optimizer runs a single time starting from the best point in the archive.
 #' The optimization stops when one of the stopping criteria is met.
 #'
-#' If `restart_strategy` is `"random"`, the optimizer runs at least for `maxeval` iterations.
+#' If `restart_strategy` is `"random"`, the optimizer runs at most for `maxeval` iterations in total.
 #' The first iteration starts with the best point in the archive and stops when one of the stopping criteria is met.
 #' The next iterations start from a random point.
 #'

--- a/man/AcqOptimizerDirect.Rd
+++ b/man/AcqOptimizerDirect.Rd
@@ -15,7 +15,7 @@ The first iteration starts with the best point in the archive and the next itera
 If the restart strategy is \code{"none"}, the optimizer starts with the best point in the archive.
 The optimization stops when one of the stopping criteria is met.
 
-If \code{restart_strategy} is \code{"random"}, the optimizer runs at least for \code{maxeval} iterations.
+If \code{restart_strategy} is \code{"random"}, the optimizer runs at most for \code{maxeval} iterations in total.
 The first iteration starts with the best point in the archive and stops when one of the stopping criteria is met.
 The next iterations start from a random point.
 }
@@ -29,7 +29,7 @@ Default is \code{"none"}.
 }
 \item{\code{max_restarts}}{\code{integer(1)}\cr
 Maximum number of restarts.
-Default is \code{5 * D} (Default).}
+Default is \code{5 * D}, where \code{D} is the dimension of the search space.}
 }
 }
 
@@ -54,7 +54,7 @@ Absolute tolerance of the parameters.
 Deactivate with \code{-1} (Default).}
 \item{\code{ftol_rel}}{\code{numeric(1)}\cr
 Relative tolerance of the objective function.
-Deactivate with \code{-1}. (Default).}
+Deactivate with \code{-1} (Default).}
 \item{\code{ftol_abs}}{\code{numeric(1)}\cr
 Absolute tolerance of the objective function.
 Deactivate with \code{-1} (Default).}

--- a/man/AcqOptimizerLbfgsb.Rd
+++ b/man/AcqOptimizerLbfgsb.Rd
@@ -5,17 +5,18 @@
 \title{L-BFGS-B Acquisition Function Optimizer}
 \description{
 L-BFGS-B acquisition function optimizer.
-Calls \code{nloptr()} from \CRANpkg{nloptr}.
-In its default setting, the algorithm restarts \code{5 * D} times and runs at most for \code{100 * D^2} function evaluations,
-where \code{D} is the dimension of the search space.
-Each run stops when the relative tolerance of the parameters is less than \code{10^-4}.
-The first iteration starts with the best point in the archive and the next iterations start from a random point.
+Calls \code{nloptr()} from \CRANpkg{nloptr} with the \code{NLOPT_LD_LBFGS} algorithm.
+In its default setting, the algorithm runs a single time starting from the best point in the archive,
+for at most \code{100 * D^2} function evaluations, where \code{D} is the dimension of the search space.
+The run stops when the relative tolerance of the parameters is less than \code{10^-4}.
+With \code{restart_strategy = "random"}, the optimizer additionally restarts from random points until the evaluation
+budget is exhausted, which can help escape local optima.
 }
 \note{
-If the restart strategy is \code{"none"}, the optimizer starts with the best point in the archive.
+If the restart strategy is \code{"none"}, the optimizer runs a single time starting from the best point in the archive.
 The optimization stops when one of the stopping criteria is met.
 
-If \code{restart_strategy} is \code{"random"}, the optimizer runs at least for \code{maxeval} iterations.
+If \code{restart_strategy} is \code{"random"}, the optimizer runs at most for \code{maxeval} iterations in total.
 The first iteration starts with the best point in the archive and stops when one of the stopping criteria is met.
 The next iterations start from a random point.
 }
@@ -29,7 +30,7 @@ Default is \code{"none"}.
 }
 \item{\code{max_restarts}}{\code{integer(1)}\cr
 Maximum number of restarts.
-Default is \code{5 * D} (Default).}
+Default is \code{5 * D}, where \code{D} is the dimension of the search space.}
 }
 }
 


### PR DESCRIPTION
## Summary

The documentation of `AcqOptimizerDirect` and `AcqOptimizerLbfgsb` had drifted from the actual defaults and behaviour:

- `AcqOptimizerLbfgsb` described a `5 * D` random-restart default even though its default `restart_strategy` is `"none"` (a single run).
- Both `@note` sections claimed the optimizer runs "at least" `maxeval` iterations, while the loop condition makes it "at most".
- The `max_restarts` documentation contained the duplicated text "Default is `5 * D` (Default)".
- `AcqOptimizerDirect`'s `ftol_rel` documentation had a stray period ("Deactivate with `-1`. (Default).").

## Changes

- Rewrite the `AcqOptimizerLbfgsb` description to match the single-run default and describe optional random restarts.
- Fix the "at least" → "at most" wording in both `@note` sections.
- Remove the duplicated "(Default)" and the stray period.
- Regenerate the man pages.

Documentation only. Addresses review finding **R16**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)