### PR TITLE
fix: populate AcqOptimizerLocalSearch state and fix cmaes doc

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * fix: `AcqFunctionMulti` can now be deep cloned without error and preserves the shared surrogate across the wrapped acquisition functions.
 * fix: `AcqOptimizerDirect`, `AcqOptimizerLbfgsb`, `AcqOptimizerLocalSearch`, and `AcqOptimizerRandomSearch` can now be deep cloned without error.
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.
+* fix: `AcqOptimizerLocalSearch` now populates its `state` field with the result of the last `bbotk::local_search()` call and clears it on `reset()`, and no longer references the unavailable `cmaes` package in its documentation.
 * fix: `OptimizerADBO` and `TunerADBO` now draw the initial lambda from an exponential distribution as documented, so that the `lambda` parameter has an effect.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
 * fix: `srlrn()` now correctly unwraps a single learner supplied in a list instead of erroring.

--- a/R/AcqOptimizerLocalSearch.R
+++ b/R/AcqOptimizerLocalSearch.R
@@ -16,7 +16,7 @@ AcqOptimizerLocalSearch = R6Class(
   inherit = AcqOptimizer,
   public = list(
     #' @field state (`list()`)\cr
-    #' List of [cmaes::cma_es()] results.
+    #' Result of the last [bbotk::local_search()] call.
     state = NULL,
 
     #' @description
@@ -68,6 +68,7 @@ AcqOptimizerLocalSearch = R6Class(
       } else {
         res = optimize()
       }
+      self$state = res
       as.data.table(as.list(set_names(
         c(res$x, res$y),
         c(self$acq_function$domain$ids(), self$acq_function$codomain$ids())
@@ -77,8 +78,10 @@ AcqOptimizerLocalSearch = R6Class(
     #' @description
     #' Reset the acquisition function optimizer.
     #'
-    #' Currently not used.
-    reset = function() {}
+    #' Clears the `state` of the previous optimization run.
+    reset = function() {
+      self$state = NULL
+    }
   ),
 
   active = list(

--- a/man/AcqOptimizerLocalSearch.Rd
+++ b/man/AcqOptimizerLocalSearch.Rd
@@ -19,7 +19,7 @@ acqo("local_search")
   \if{html}{\out{<div class="r6-fields">}}
   \describe{
     \item{\code{state}}{(\code{list()})\cr
-List of \code{\link[cmaes:cma_es]{cmaes::cma_es()}} results.}
+Result of the last \code{\link[bbotk:local_search]{bbotk::local_search()}} call.}
   }
   \if{html}{\out{</div>}}
 }
@@ -93,7 +93,7 @@ String in the format \verb{[pkg]::[topic]} pointing to a manual page for this ob
 \subsection{\code{AcqOptimizerLocalSearch$reset()}}{
   Reset the acquisition function optimizer.
 
-Currently not used.
+Clears the \code{state} of the previous optimization run.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{AcqOptimizerLocalSearch$reset()}

--- a/tests/testthat/test_AcqOptimizerLocalSearch.R
+++ b/tests/testthat/test_AcqOptimizerLocalSearch.R
@@ -13,6 +13,12 @@ test_that("AcqOptimizerLocalSearch works", {
   res = acqopt$optimize()
   expect_data_table(res, nrows = 1L, ncols = 2L)
   expect_names(names(res), must.include = c("x", "acq_ei"))
+
+  # state is populated with the local_search result and cleared on reset
+  expect_list(acqopt$state)
+  expect_names(names(acqopt$state), must.include = c("x", "y"))
+  acqopt$reset()
+  expect_null(acqopt$state)
 })
 
 test_that("AcqOptimizerLocalSearch works with 2D", {


### PR DESCRIPTION
## Summary

`AcqOptimizerLocalSearch` documented its `state` field as "List of `cmaes::cma_es()` results" — a copy-paste from a CMA-ES implementation. This class actually calls `bbotk::local_search()` and never assigned `state`, so the field was always `NULL`. `cmaes` is not a dependency, so the dangling `\link{cmaes}` produced an R CMD check note.

## Changes

- Populate `state` with the result of the last `bbotk::local_search()` call.
- Clear `state` in `reset()`.
- Fix the `@field state` documentation to reference `bbotk::local_search()`.
- Add assertions on `state` and `reset()` to the existing test.

Addresses review finding **R17**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)