### PR TITLE
fix: honor skip_already_evaluated in AcqOptimizer subclasses

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * fix: `AcqFunctionEHVI`, `AcqFunctionEHVIGH`, and `AcqFunctionSmsEgo` now apply the surrogate's output transformation to `ys_front`, so the front and the reference point are compared on the same scale.
 * fix: `AcqFunctionEIPS` now correctly divides the expected improvement by the predicted time instead of behaving like plain expected improvement.
 * fix: `AcqFunctionMulti` can now be deep cloned without error and preserves the shared surrogate across the wrapped acquisition functions.
+* fix: `AcqOptimizerDirect`, `AcqOptimizerLbfgsb`, `AcqOptimizerLocalSearch`, and `AcqOptimizerRandomSearch` now support the `skip_already_evaluated` parameter (default `TRUE`) and reject an already evaluated candidate, so an `AcqOptimizerLbfgsb` starting at the incumbent no longer re-proposes and re-evaluates the same point every iteration.
 * fix: `AcqOptimizerDirect`, `AcqOptimizerLbfgsb`, `AcqOptimizerLocalSearch`, and `AcqOptimizerRandomSearch` can now be deep cloned without error.
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.
 * fix: `OptimizerADBO` and `TunerADBO` now draw the initial lambda from an exponential distribution as documented, so that the `lambda` parameter has an effect.

--- a/R/AcqOptimizerDirect.R
+++ b/R/AcqOptimizerDirect.R
@@ -20,6 +20,11 @@
 #' \item{`max_restarts`}{`integer(1)`\cr
 #'   Maximum number of restarts.
 #'   Default is `5 * D` (Default).}
+#' \item{`skip_already_evaluated`}{`logical(1)`\cr
+#'   Should the proposed candidate be rejected if it was already evaluated on the actual [bbotk::OptimInstance]?
+#'   If `TRUE` and the candidate was already evaluated, an error is raised so that the `loop_function` can
+#'   propose a randomly sampled point instead.
+#'   Default is `TRUE`.}
 #' }
 #'
 #' @note
@@ -85,6 +90,7 @@ AcqOptimizerDirect = R6Class(
         minf_max = p_dbl(default = -Inf),
         restart_strategy = p_fct(levels = c("none", "random"), init = "random"),
         max_restarts = p_int(lower = 0L),
+        skip_already_evaluated = p_lgl(init = TRUE),
         catch_errors = p_lgl(init = TRUE)
       )
       private$.param_set = param_set
@@ -100,10 +106,12 @@ AcqOptimizerDirect = R6Class(
       max_restarts = pv$max_restarts
       maxeval = pv$maxeval
       catch_errors = pv$catch_errors
+      skip_already_evaluated = pv$skip_already_evaluated
       pv$max_restarts = NULL
       pv$restart_strategy = NULL
       pv$maxeval = NULL
       pv$catch_errors = NULL
+      pv$skip_already_evaluated = NULL
 
       if (restart_strategy == "none") {
         max_restarts = 0L
@@ -177,10 +185,14 @@ AcqOptimizerDirect = R6Class(
 
         if (restart_strategy == "none") break
       }
-      as.data.table(as.list(set_names(
+      xdt = as.data.table(as.list(set_names(
         c(x, y * direction),
         c(self$acq_function$domain$ids(), self$acq_function$codomain$ids())
       )))
+      if (skip_already_evaluated) {
+        assert_not_already_evaluated(xdt, self$acq_function$archive)
+      }
+      xdt
     }
   ),
 

--- a/R/AcqOptimizerLbfgsb.R
+++ b/R/AcqOptimizerLbfgsb.R
@@ -20,6 +20,11 @@
 #' \item{`max_restarts`}{`integer(1)`\cr
 #'   Maximum number of restarts.
 #'   Default is `5 * D` (Default).}
+#' \item{`skip_already_evaluated`}{`logical(1)`\cr
+#'   Should the proposed candidate be rejected if it was already evaluated on the actual [bbotk::OptimInstance]?
+#'   If `TRUE` and the candidate was already evaluated, an error is raised so that the `loop_function` can
+#'   propose a randomly sampled point instead.
+#'   Default is `TRUE`.}
 #' }
 #'
 #' @note
@@ -85,6 +90,7 @@ AcqOptimizerLbfgsb = R6Class(
         minf_max = p_dbl(default = -Inf),
         restart_strategy = p_fct(levels = c("none", "random"), init = "none"),
         max_restarts = p_int(lower = 0L),
+        skip_already_evaluated = p_lgl(init = TRUE),
         catch_errors = p_lgl(init = TRUE)
       )
       private$.param_set = param_set
@@ -100,10 +106,12 @@ AcqOptimizerLbfgsb = R6Class(
       max_restarts = pv$max_restarts
       maxeval = pv$maxeval
       catch_errors = pv$catch_errors
+      skip_already_evaluated = pv$skip_already_evaluated
       pv$max_restarts = NULL
       pv$restart_strategy = NULL
       pv$maxeval = NULL
       pv$catch_errors = NULL
+      pv$skip_already_evaluated = NULL
 
       if (restart_strategy == "none") {
         max_restarts = 0L
@@ -197,10 +205,14 @@ AcqOptimizerLbfgsb = R6Class(
 
         if (restart_strategy == "none") break
       }
-      as.data.table(as.list(set_names(
+      xdt = as.data.table(as.list(set_names(
         c(x, y * direction),
         c(self$acq_function$domain$ids(), self$acq_function$codomain$ids())
       )))
+      if (skip_already_evaluated) {
+        assert_not_already_evaluated(xdt, self$acq_function$archive)
+      }
+      xdt
     }
   ),
 

--- a/R/AcqOptimizerLocalSearch.R
+++ b/R/AcqOptimizerLocalSearch.R
@@ -8,6 +8,9 @@
 #' For the meaning of the control parameters, see [bbotk::local_search_control()].
 #' The termination stops when the budget defined by the `n_searches`, `n_steps`, and `n_neighs` parameters is exhausted.
 #'
+#' If `skip_already_evaluated` is `TRUE` (default) and the proposed candidate was already evaluated on the actual
+#' [bbotk::OptimInstance], an error is raised so that the `loop_function` can propose a randomly sampled point instead.
+#'
 #' @export
 #' @examples
 #' acqo("local_search")
@@ -31,6 +34,7 @@ AcqOptimizerLocalSearch = R6Class(
         n_neighs = p_int(lower = 1L, default = 10L),
         mut_sd = p_dbl(lower = 0, default = 0.1),
         stagnate_max = p_int(lower = 1L, default = 10L),
+        skip_already_evaluated = p_lgl(init = TRUE),
         catch_errors = p_lgl(init = TRUE)
       )
       private$.param_set = param_set
@@ -45,7 +49,7 @@ AcqOptimizerLocalSearch = R6Class(
       control = invoke(
         bbotk::local_search_control,
         minimize = self$acq_function$codomain$direction == 1L,
-        .args = pv[names(pv) != "catch_errors"]
+        .args = pv[names(pv) %nin% c("catch_errors", "skip_already_evaluated")]
       )
 
       wrapper = function(xdt) {
@@ -68,10 +72,14 @@ AcqOptimizerLocalSearch = R6Class(
       } else {
         res = optimize()
       }
-      as.data.table(as.list(set_names(
+      xdt = as.data.table(as.list(set_names(
         c(res$x, res$y),
         c(self$acq_function$domain$ids(), self$acq_function$codomain$ids())
       )))
+      if (pv$skip_already_evaluated) {
+        assert_not_already_evaluated(xdt, self$acq_function$archive)
+      }
+      xdt
     },
 
     #' @description

--- a/R/AcqOptimizerRandomSearch.R
+++ b/R/AcqOptimizerRandomSearch.R
@@ -12,6 +12,11 @@
 #' \item{`n_evals`}{`integer(1)`\cr
 #'   Number of random points to sample.
 #'   Default is `100 * D^2`, where `D` is the dimension of the search space.}
+#' \item{`skip_already_evaluated`}{`logical(1)`\cr
+#'   Should the proposed candidate be rejected if it was already evaluated on the actual [bbotk::OptimInstance]?
+#'   If `TRUE` and the candidate was already evaluated, an error is raised so that the `loop_function` can
+#'   propose a randomly sampled point instead.
+#'   Default is `TRUE`.}
 #' }
 #' @export
 #' @examples
@@ -28,6 +33,7 @@ AcqOptimizerRandomSearch = R6Class(
       self$acq_function = assert_r6(acq_function, "AcqFunction", null.ok = TRUE)
       param_set = ps(
         n_evals = p_int(lower = 1),
+        skip_already_evaluated = p_lgl(init = TRUE),
         catch_errors = p_lgl(init = TRUE)
       )
       private$.param_set = param_set
@@ -71,6 +77,9 @@ AcqOptimizerRandomSearch = R6Class(
       y = ys[id]
 
       set(x, j = self$acq_function$codomain$ids(), value = y)
+      if (pv$skip_already_evaluated) {
+        assert_not_already_evaluated(x, self$acq_function$archive)
+      }
       x
     }
   ),

--- a/R/helper.R
+++ b/R/helper.R
@@ -124,6 +124,17 @@ get_best = function(instance, is_multi_acq_function, evaluated, n_select, not_al
   }
 }
 
+# used in AcqOptimizer subclasses that produce a single candidate;
+# raises an acq optimizer error when the proposed candidate was already evaluated on the actual instance
+assert_not_already_evaluated = function(xdt, archive) {
+  cols_x = archive$cols_x
+  matched = archive$data[xdt[, cols_x, with = FALSE], on = cols_x, nomatch = NULL, which = TRUE]
+  if (length(matched)) {
+    error_acq_optimizer("Acquisition function optimization proposed an already evaluated candidate.")
+  }
+  xdt
+}
+
 catn = function(..., file = "") {
   cat(paste0(..., collapse = "\n"), "\n", sep = "", file = file)
 }

--- a/man/AcqOptimizerDirect.Rd
+++ b/man/AcqOptimizerDirect.Rd
@@ -30,6 +30,11 @@ Default is \code{"none"}.
 \item{\code{max_restarts}}{\code{integer(1)}\cr
 Maximum number of restarts.
 Default is \code{5 * D} (Default).}
+\item{\code{skip_already_evaluated}}{\code{logical(1)}\cr
+Should the proposed candidate be rejected if it was already evaluated on the actual \link[bbotk:OptimInstance]{bbotk::OptimInstance}?
+If \code{TRUE} and the candidate was already evaluated, an error is raised so that the \code{loop_function} can
+propose a randomly sampled point instead.
+Default is \code{TRUE}.}
 }
 }
 

--- a/man/AcqOptimizerLbfgsb.Rd
+++ b/man/AcqOptimizerLbfgsb.Rd
@@ -30,6 +30,11 @@ Default is \code{"none"}.
 \item{\code{max_restarts}}{\code{integer(1)}\cr
 Maximum number of restarts.
 Default is \code{5 * D} (Default).}
+\item{\code{skip_already_evaluated}}{\code{logical(1)}\cr
+Should the proposed candidate be rejected if it was already evaluated on the actual \link[bbotk:OptimInstance]{bbotk::OptimInstance}?
+If \code{TRUE} and the candidate was already evaluated, an error is raised so that the \code{loop_function} can
+propose a randomly sampled point instead.
+Default is \code{TRUE}.}
 }
 }
 

--- a/man/AcqOptimizerLocalSearch.Rd
+++ b/man/AcqOptimizerLocalSearch.Rd
@@ -8,6 +8,9 @@ Local search acquisition function optimizer.
 Calls \code{\link[bbotk:local_search]{bbotk::local_search()}}.
 For the meaning of the control parameters, see \code{\link[bbotk:local_search_control]{bbotk::local_search_control()}}.
 The termination stops when the budget defined by the \code{n_searches}, \code{n_steps}, and \code{n_neighs} parameters is exhausted.
+
+If \code{skip_already_evaluated} is \code{TRUE} (default) and the proposed candidate was already evaluated on the actual
+\link[bbotk:OptimInstance]{bbotk::OptimInstance}, an error is raised so that the \code{loop_function} can propose a randomly sampled point instead.
 }
 \examples{
 acqo("local_search")

--- a/man/AcqOptimizerRandomSearch.Rd
+++ b/man/AcqOptimizerRandomSearch.Rd
@@ -14,6 +14,11 @@ The point with the highest acquisition value is returned.
 \item{\code{n_evals}}{\code{integer(1)}\cr
 Number of random points to sample.
 Default is \code{100 * D^2}, where \code{D} is the dimension of the search space.}
+\item{\code{skip_already_evaluated}}{\code{logical(1)}\cr
+Should the proposed candidate be rejected if it was already evaluated on the actual \link[bbotk:OptimInstance]{bbotk::OptimInstance}?
+If \code{TRUE} and the candidate was already evaluated, an error is raised so that the \code{loop_function} can
+propose a randomly sampled point instead.
+Default is \code{TRUE}.}
 }
 }
 

--- a/tests/testthat/test_AcqOptimizerDirect.R
+++ b/tests/testthat/test_AcqOptimizerDirect.R
@@ -53,6 +53,12 @@ test_that("AcqOptimizerDirect works with instance", {
   expect_data_table(optimizer$optimize(instance), nrows = 1L)
 })
 
+test_that("AcqOptimizerDirect has skip_already_evaluated enabled by default", {
+  acqopt = AcqOptimizerDirect$new()
+  expect_true("skip_already_evaluated" %in% acqopt$param_set$ids())
+  expect_true(acqopt$param_set$values$skip_already_evaluated)
+})
+
 test_that("AcqOptimizerDirect works with random restart", {
   skip_if_missing_regr_km()
   instance = oi(OBJ_2D, terminator = trm("evals", n_evals = 5L))

--- a/tests/testthat/test_AcqOptimizerLbfgsb.R
+++ b/tests/testthat/test_AcqOptimizerLbfgsb.R
@@ -7,7 +7,8 @@ test_that("AcqOptimizerLbfgsb works", {
   surrogate = srlrn(REGR_KM_DETERM, archive = instance$archive)
   acqfun = acqf("ei", surrogate = surrogate)
   acqopt = AcqOptimizerLbfgsb$new(acq_function = acqfun)
-  acqopt$param_set$set_values(maxeval = 200L, restart_strategy = "none")
+  # L-BFGS-B starts at and can return the incumbent here, so disable skip_already_evaluated for this smoke test
+  acqopt$param_set$set_values(maxeval = 200L, restart_strategy = "none", skip_already_evaluated = FALSE)
   acqfun$surrogate$update()
   acqfun$update()
 
@@ -16,6 +17,23 @@ test_that("AcqOptimizerLbfgsb works", {
   expect_names(names(acqopt$state), must.include = "iteration_1")
   expect_class(acqopt$state$iteration_1$model, "nloptr")
   expect_true(acqopt$state$iteration_1$model$iterations <= 200L)
+})
+
+test_that("AcqOptimizerLbfgsb rejects an already evaluated candidate when skip_already_evaluated is TRUE", {
+  skip_if_missing_regr_km()
+  instance = oi(OBJ_1D, terminator = trm("evals", n_evals = 5L))
+  instance$eval_batch(generate_design_grid(instance$search_space, resolution = 4L)$data)
+  surrogate = srlrn(REGR_KM_DETERM, archive = instance$archive)
+  acqfun = acqf("ei", surrogate = surrogate)
+  acqopt = AcqOptimizerLbfgsb$new(acq_function = acqfun)
+  acqopt$param_set$set_values(maxeval = 200L, restart_strategy = "none")
+  acqfun$surrogate$update()
+  acqfun$update()
+
+  # the incumbent is re-proposed, which is rejected by default and accepted with skip_already_evaluated = FALSE
+  expect_error(acqopt$optimize(), class = "Mlr3ErrorMboAcqOptimizer")
+  acqopt$param_set$set_values(skip_already_evaluated = FALSE)
+  expect_data_table(acqopt$optimize(), nrows = 1L)
 })
 
 test_that("AcqOptimizerLbfgsb works with 2D", {

--- a/tests/testthat/test_AcqOptimizerLocalSearch.R
+++ b/tests/testthat/test_AcqOptimizerLocalSearch.R
@@ -15,6 +15,12 @@ test_that("AcqOptimizerLocalSearch works", {
   expect_names(names(res), must.include = c("x", "acq_ei"))
 })
 
+test_that("AcqOptimizerLocalSearch has skip_already_evaluated enabled by default", {
+  acqopt = AcqOptimizerLocalSearch$new()
+  expect_true("skip_already_evaluated" %in% acqopt$param_set$ids())
+  expect_true(acqopt$param_set$values$skip_already_evaluated)
+})
+
 test_that("AcqOptimizerLocalSearch works with 2D", {
   skip_if_missing_regr_km()
   instance = oi(OBJ_2D, terminator = trm("evals", n_evals = 5L))

--- a/tests/testthat/test_AcqOptimizerRandomSearch.R
+++ b/tests/testthat/test_AcqOptimizerRandomSearch.R
@@ -14,6 +14,12 @@ test_that("AcqOptimizerRandomSearch works", {
   expect_data_table(acqopt$optimize(), nrows = 1L)
 })
 
+test_that("AcqOptimizerRandomSearch has skip_already_evaluated enabled by default", {
+  acqopt = AcqOptimizerRandomSearch$new()
+  expect_true("skip_already_evaluated" %in% acqopt$param_set$ids())
+  expect_true(acqopt$param_set$values$skip_already_evaluated)
+})
+
 test_that("AcqOptimizerRandomSearch works with 2D", {
   skip_if_missing_regr_km()
   instance = oi(OBJ_2D, terminator = trm("evals", n_evals = 5L))


### PR DESCRIPTION
## Summary

The four `AcqOptimizer` subclasses (`AcqOptimizerDirect`, `AcqOptimizerLbfgsb`, `AcqOptimizerLocalSearch`, `AcqOptimizerRandomSearch`) override `optimize()` entirely and silently dropped the `skip_already_evaluated` safeguard that the parent `AcqOptimizer` documents and defaults to `TRUE`. `AcqOptimizerLbfgsb` even *starts* at the incumbent, so when the acquisition surface pulls back to it (e.g. `acqf(\"mean\")`, CB with small lambda, or a converged EI), the same point was re-proposed and re-evaluated every iteration until termination.

## Changes

- Add a `skip_already_evaluated` parameter (default `TRUE`) to each of the four subclasses.
- Add a shared `assert_not_already_evaluated()` helper that raises a catchable `error_acq_optimizer()` (class `Mlr3ErrorMboAcqOptimizer`) when the proposed candidate already exists in the actual instance archive, so the `loop_function` falls back to a randomly sampled point (mirroring the parent's behaviour).
- Make sure the new parameter is not leaked into the `nloptr`/`local_search` control options.
- Document the parameter and add tests (including a test showing L-BFGS-B rejecting the re-proposed incumbent by default and accepting it with `skip_already_evaluated = FALSE`).

Addresses review finding **R18**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)