### PR TITLE
fix: pass id argument through in OptimizerAsyncMbo

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * fix: `AcqOptimizerLbfgsb` now raises a catchable acquisition function optimizer error instead of an unrelated error when no restart produces a valid solution, so the loop function can fall back to a randomly sampled point.
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.
 * fix: `OptimizerADBO` and `TunerADBO` now draw the initial lambda from an exponential distribution as documented, so that the `lambda` parameter has an effect.
+* fix: `OptimizerAsyncMbo` no longer ignores its `id` construction argument, so `OptimizerADBO` and `TunerADBO` now correctly report the id `"adbo"` instead of `"async_mbo"`.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
 * fix: `ResultAssignerSurrogate` no longer errors when the archive contains duplicated x-configurations.
 * fix: `srlrn()` now correctly unwraps a single learner supplied in a list instead of erroring.

--- a/R/OptimizerAsyncMbo.R
+++ b/R/OptimizerAsyncMbo.R
@@ -160,7 +160,7 @@ OptimizerAsyncMbo = R6Class(
       param_set$set_values(design_size = 100L, design_function = "sobol")
 
       super$initialize(
-        "async_mbo",
+        id = id,
         param_set = param_set,
         # is replaced with dynamic AB after construction
         param_classes = c("ParamLgl", "ParamInt", "ParamDbl", "ParamFct"),

--- a/tests/testthat/test_OptimizerAsyncMbo.R
+++ b/tests/testthat/test_OptimizerAsyncMbo.R
@@ -46,3 +46,9 @@ test_that("OptimizerAsyncMbo works with evaluations in archive", {
   expect_data_table(instance$archive$data[is.na(get("acq_cb"))], min.rows = 10L)
   expect_data_table(instance$archive$data[!is.na(get("acq_cb"))], min.rows = 20L)
 })
+
+test_that("OptimizerAsyncMbo passes the id argument through", {
+  expect_equal(OptimizerAsyncMbo$new()$id, "async_mbo")
+  expect_equal(OptimizerAsyncMbo$new(id = "custom")$id, "custom")
+  expect_equal(OptimizerADBO$new()$id, "adbo")
+})


### PR DESCRIPTION
## Summary

- `OptimizerAsyncMbo$initialize()` accepted an `id` argument but hardcoded `"async_mbo"` in the `super$initialize()` call.
- As a result, `OptimizerADBO$new()$id` and `TunerADBO$new()$id` were `"async_mbo"` instead of `"adbo"`, and all bbotk log lines were mislabeled for ADBO.
- The `id` argument is now passed through; a test asserts the wiring for `OptimizerAsyncMbo` (default and custom id) and `OptimizerADBO`.

Addresses R19 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)