### PR TITLE
fix: register final surrogate update before running the loop function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * fix: `AcqOptimizerLbfgsb` now raises a catchable acquisition function optimizer error instead of an unrelated error when no restart produces a valid solution, so the loop function can fall back to a randomly sampled point.
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.
 * fix: `OptimizerADBO` and `TunerADBO` now draw the initial lambda from an exponential distribution as documented, so that the `lambda` parameter has an effect.
+* fix: `OptimizerMbo` and `TunerMbo` now update the surrogate a final time even when the optimization exits through a termination error, e.g., when the archive is already at budget or the terminator triggers between two evaluations.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
 * fix: `ResultAssignerSurrogate` no longer errors when the archive contains duplicated x-configurations.
 * fix: `srlrn()` now correctly unwraps a single learner supplied in a list instead of erroring.

--- a/R/OptimizerMbo.R
+++ b/R/OptimizerMbo.R
@@ -421,6 +421,21 @@ OptimizerMbo = R6Class(
     .result_assigner = NULL,
 
     .optimize = function(inst) {
+      on.exit(
+        {
+          tryCatch(
+            {
+              self$surrogate$update()
+            },
+            Mlr3ErrorMboSurrogateUpdate = function(error_condition) {
+              lg = lgr::get_logger("mlr3/bbotk")
+              lg$warn("Could not update the surrogate a final time after the optimization process has terminated.")
+            }
+          )
+        },
+        add = TRUE
+      )
+
       invoke(
         self$loop_function,
         instance = inst,
@@ -429,18 +444,6 @@ OptimizerMbo = R6Class(
         acq_optimizer = self$acq_optimizer,
         .args = self$args
       )
-
-      on.exit({
-        tryCatch(
-          {
-            self$surrogate$update()
-          },
-          Mlr3ErrorMboSurrogateUpdate = function(error_condition) {
-            lg = lgr::get_logger("mlr3/bbotk")
-            lg$warn("Could not update the surrogate a final time after the optimization process has terminated.")
-          }
-        )
-      })
     },
 
     .assign_result = function(inst) {

--- a/tests/testthat/test_OptimizerMbo.R
+++ b/tests/testthat/test_OptimizerMbo.R
@@ -244,3 +244,21 @@ test_that("OptimizerMbo up to date surrogate after optimization", {
   expect_true(all(sqrt((predictions$mean - instance$archive$data$y)^2) < 1e-4))
   expect_true(all(predictions$se < 1e-4))
 })
+
+test_that("OptimizerMbo updates the surrogate a final time when terminated during random interleaving", {
+  surrogate = srlrn(lrn("regr.featureless"))
+  optimizer = opt(
+    "mbo",
+    loop_function = bayesopt_ego,
+    surrogate = surrogate,
+    acq_function = acqf("ei"),
+    acq_optimizer = acqo(opt("random_search", batch_size = 2L), terminator = trm("evals", n_evals = 2L)),
+    args = list(init_design_size = 5L, random_interleave_iter = 1L)
+  )
+  instance = MAKE_INST_1D(terminator = trm("evals", n_evals = 5L))
+  instance$eval_batch(MAKE_DESIGN(instance, n = 5L))
+
+  optimizer$optimize(instance)
+
+  expect_true(optimizer$surrogate$learner$state$train_task$nrow == 5L)
+})


### PR DESCRIPTION
## Summary

- The `on.exit()` handler that performs the documented final surrogate update in `OptimizerMbo$.optimize()` was registered *after* `invoke(self$loop_function, ...)`, so it never ran on any error path, including the routine `Mlr3ErrorBbotkTerminated` control-flow exit (pre-filled archive at budget, terminator triggering between the break check and the next `eval_batch()`).
- The handler is now registered with `on.exit(..., add = TRUE)` before the loop function is invoked.
- Adds a regression test in which the last iteration is a random interleave, so the loop terminates via the termination error with a stale surrogate; without the fix the surrogate is never trained.

Addresses R20 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)