### PR TITLE
fix: catch plain errors in the best-effort final surrogate update

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * fix: `AcqOptimizerLbfgsb` now raises a catchable acquisition function optimizer error instead of an unrelated error when no restart produces a valid solution, so the loop function can fall back to a randomly sampled point.
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.
 * fix: `OptimizerADBO` and `TunerADBO` now draw the initial lambda from an exponential distribution as documented, so that the `lambda` parameter has an effect.
+* fix: `OptimizerMbo` and `TunerMbo` now update the surrogate a final time even when the optimization exits through a termination error, e.g., when the archive is already at budget or the terminator triggers between two evaluations.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
 * fix: `ResultAssignerSurrogate` no longer errors when the archive contains duplicated x-configurations.
 * fix: `srlrn()` now correctly unwraps a single learner supplied in a list instead of erroring.

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.
 * fix: `OptimizerADBO` and `TunerADBO` now draw the initial lambda from an exponential distribution as documented, so that the `lambda` parameter has an effect.
 * fix: `OptimizerMbo` and `TunerMbo` now update the surrogate a final time even when the optimization exits through a termination error, e.g., when the archive is already at budget or the terminator triggers between two evaluations.
+* fix: `OptimizerMbo` and `OptimizerAsyncMbo` no longer abort a successful run when the final surrogate update fails with a plain error, e.g., when the surrogate is configured with `catch_errors = FALSE`.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
 * fix: `ResultAssignerSurrogate` no longer errors when the archive contains duplicated x-configurations.
 * fix: `srlrn()` now correctly unwraps a single learner supplied in a list instead of erroring.

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 * fix: `OptimizerADBO` and `TunerADBO` now draw the initial lambda from an exponential distribution as documented, so that the `lambda` parameter has an effect.
 * fix: `OptimizerMbo` and `TunerMbo` now update the surrogate a final time even when the optimization exits through a termination error, e.g., when the archive is already at budget or the terminator triggers between two evaluations.
 * fix: `OptimizerMbo` and `OptimizerAsyncMbo` no longer abort a successful run when the final surrogate update fails with a plain error, e.g., when the surrogate is configured with `catch_errors = FALSE`.
+* fix: `OptimizerAsyncMbo`, `OptimizerADBO`, `TunerAsyncMbo`, and `TunerADBO` now perform the final surrogate update on the main process, so the user-facing surrogate reflects all available data after optimization instead of remaining untrained.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
 * fix: `ResultAssignerSurrogate` no longer errors when the archive contains duplicated x-configurations.
 * fix: `srlrn()` now correctly unwraps a single learner supplied in a list instead of erroring.

--- a/R/OptimizerAsyncMbo.R
+++ b/R/OptimizerAsyncMbo.R
@@ -424,7 +424,7 @@ OptimizerAsyncMbo = R6Class(
           {
             self$surrogate$update()
           },
-          Mlr3ErrorMboSurrogateUpdate = function(error_condition) {
+          error = function(error_condition) {
             lg$warn("Could not update the surrogate a final time after the optimization process has terminated.")
           }
         )

--- a/R/OptimizerAsyncMbo.R
+++ b/R/OptimizerAsyncMbo.R
@@ -276,7 +276,19 @@ OptimizerAsyncMbo = R6Class(
         lg$debug("Using provided initial design with size %s", nrow(pv$initial_design))
         pv$initial_design
       }
-      optimize_async_default(inst, self, design, n_workers = pv$n_workers)
+      result = optimize_async_default(inst, self, design, n_workers = pv$n_workers)
+
+      # the workers only update copies of the surrogate, so the final update must happen on the main process
+      tryCatch(
+        {
+          self$surrogate$update()
+        },
+        error = function(error_condition) {
+          lg$warn("Could not update the surrogate a final time after the optimization process has terminated.")
+        }
+      )
+
+      result
     }
   ),
 
@@ -418,17 +430,6 @@ OptimizerAsyncMbo = R6Class(
         # eval
         get_private(inst)$.eval_point(xs)
       }
-
-      on.exit({
-        tryCatch(
-          {
-            self$surrogate$update()
-          },
-          error = function(error_condition) {
-            lg$warn("Could not update the surrogate a final time after the optimization process has terminated.")
-          }
-        )
-      })
     },
 
     .assign_result = function(inst) {

--- a/R/OptimizerMbo.R
+++ b/R/OptimizerMbo.R
@@ -421,6 +421,21 @@ OptimizerMbo = R6Class(
     .result_assigner = NULL,
 
     .optimize = function(inst) {
+      on.exit(
+        {
+          tryCatch(
+            {
+              self$surrogate$update()
+            },
+            Mlr3ErrorMboSurrogateUpdate = function(error_condition) {
+              lg = lgr::get_logger("mlr3/bbotk")
+              lg$warn("Could not update the surrogate a final time after the optimization process has terminated.")
+            }
+          )
+        },
+        add = TRUE
+      )
+
       invoke(
         self$loop_function,
         instance = inst,
@@ -429,18 +444,6 @@ OptimizerMbo = R6Class(
         acq_optimizer = self$acq_optimizer,
         .args = self$args
       )
-
-      on.exit({
-        tryCatch(
-          {
-            self$surrogate$update()
-          },
-          Mlr3ErrorMboSurrogateUpdate = function(error_condition) {
-            lg = lgr::get_logger("mlr3/bbotk")
-            lg$warn("Could not update the surrogate a final time after the optimization process has terminated.")
-          }
-        )
-      })
     },
 
     .assign_result = function(inst) {

--- a/R/OptimizerMbo.R
+++ b/R/OptimizerMbo.R
@@ -427,7 +427,7 @@ OptimizerMbo = R6Class(
             {
               self$surrogate$update()
             },
-            Mlr3ErrorMboSurrogateUpdate = function(error_condition) {
+            error = function(error_condition) {
               lg = lgr::get_logger("mlr3/bbotk")
               lg$warn("Could not update the surrogate a final time after the optimization process has terminated.")
             }

--- a/R/OptimizerMbo.R
+++ b/R/OptimizerMbo.R
@@ -428,7 +428,6 @@ OptimizerMbo = R6Class(
               self$surrogate$update()
             },
             error = function(error_condition) {
-              lg = lgr::get_logger("mlr3/bbotk")
               lg$warn("Could not update the surrogate a final time after the optimization process has terminated.")
             }
           )

--- a/tests/testthat/test_OptimizerAsyncMbo.R
+++ b/tests/testthat/test_OptimizerAsyncMbo.R
@@ -46,3 +46,23 @@ test_that("OptimizerAsyncMbo works with evaluations in archive", {
   expect_data_table(instance$archive$data[is.na(get("acq_cb"))], min.rows = 10L)
   expect_data_table(instance$archive$data[!is.na(get("acq_cb"))], min.rows = 20L)
 })
+
+test_that("OptimizerAsyncMbo updates the surrogate on the main process after optimization", {
+  rush = start_rush(n_workers = 1)
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
+
+  instance = oi_async(
+    objective = OBJ_2D,
+    search_space = PS_2D,
+    terminator = trm("evals", n_evals = 10L),
+    rush = rush
+  )
+  optimizer = opt("async_mbo", design_function = "sobol", design_size = 5L)
+  optimizer$optimize(instance)
+
+  expect_false(is.null(optimizer$surrogate$learner$model))
+  expect_equal(optimizer$surrogate$learner$state$train_task$nrow, instance$archive$n_finished)
+})

--- a/tests/testthat/test_OptimizerMbo.R
+++ b/tests/testthat/test_OptimizerMbo.R
@@ -244,3 +244,21 @@ test_that("OptimizerMbo up to date surrogate after optimization", {
   expect_true(all(sqrt((predictions$mean - instance$archive$data$y)^2) < 1e-4))
   expect_true(all(predictions$se < 1e-4))
 })
+
+test_that("OptimizerMbo updates the surrogate a final time when terminated during random interleaving", {
+  surrogate = srlrn(lrn("regr.featureless"))
+  optimizer = opt(
+    "mbo",
+    loop_function = bayesopt_ego,
+    surrogate = surrogate,
+    acq_function = acqf("ei"),
+    acq_optimizer = acqo(opt("random_search", batch_size = 2L), terminator = trm("evals", n_evals = 2L)),
+    args = list(init_design_size = 5L, random_interleave_iter = 1L)
+  )
+  instance = MAKE_INST_1D(terminator = trm("evals", n_evals = 5L))
+  instance$eval_batch(MAKE_DESIGN(instance, n = 5L))
+
+  optimizer$optimize(instance)
+
+  expect_true(optimizer$surrogate$learner$state$train_task$nrow == 5L)
+})

--- a/tests/testthat/test_OptimizerMbo.R
+++ b/tests/testthat/test_OptimizerMbo.R
@@ -262,3 +262,24 @@ test_that("OptimizerMbo updates the surrogate a final time when terminated durin
 
   expect_true(optimizer$surrogate$learner$state$train_task$nrow == 5L)
 })
+
+test_that("OptimizerMbo does not abort a successful run when the final surrogate update fails", {
+  learner = LearnerRegrError$new()
+  learner$param_set$values$error_train = TRUE
+  surrogate = srlrn(learner)
+  surrogate$param_set$values$catch_errors = FALSE
+  optimizer = opt(
+    "mbo",
+    loop_function = bayesopt_ego,
+    surrogate = surrogate,
+    acq_function = acqf("ei"),
+    acq_optimizer = acqo(opt("random_search", batch_size = 2L), terminator = trm("evals", n_evals = 2L)),
+    args = list(init_design_size = 5L, random_interleave_iter = 1L)
+  )
+  instance = MAKE_INST_1D(terminator = trm("evals", n_evals = 5L))
+  instance$eval_batch(MAKE_DESIGN(instance, n = 5L))
+
+  optimizer$optimize(instance)
+
+  expect_data_table(instance$result, nrows = 1L)
+})


### PR DESCRIPTION
## Summary

- The final-update `tryCatch` in `OptimizerMbo$.optimize()` and `OptimizerAsyncMbo$.optimize()` only handled `Mlr3ErrorMboSurrogateUpdate`.
- With `surrogate$param_set$values$catch_errors = FALSE`, a plain error escaped the exit handler and aborted `optimize()` after a fully successful run, before `.assign_result()` — the instance ended with no result.
- The best-effort update now catches `error`, logs the established warning, and lets the run finish.
- Adds a regression test where the run succeeds but the final update fails with `catch_errors = FALSE`.

Stacked on #244 because both change the same `on.exit()` block. Addresses R21 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)