### PR TITLE
fix: perform final async surrogate update on the main process

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 * fix: `OptimizerADBO` and `TunerADBO` now draw the initial lambda from an exponential distribution as documented, so that the `lambda` parameter has an effect.
 * fix: `OptimizerMbo` and `TunerMbo` now update the surrogate a final time even when the optimization exits through a termination error, e.g., when the archive is already at budget or the terminator triggers between two evaluations.
 * fix: `OptimizerMbo` and `OptimizerAsyncMbo` no longer abort a successful run when the final surrogate update fails with a plain error, e.g., when the surrogate is configured with `catch_errors = FALSE`.
+* fix: `OptimizerAsyncMbo`, `OptimizerADBO`, `TunerAsyncMbo`, and `TunerADBO` now perform the final surrogate update on the main process, so the user-facing surrogate reflects all available data after optimization instead of remaining untrained.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
 * fix: `ResultAssignerSurrogate` no longer errors when the archive contains duplicated x-configurations.
 * fix: `srlrn()` now correctly unwraps a single learner supplied in a list instead of erroring.

--- a/R/OptimizerAsyncMbo.R
+++ b/R/OptimizerAsyncMbo.R
@@ -276,7 +276,19 @@ OptimizerAsyncMbo = R6Class(
         lg$debug("Using provided initial design with size %s", nrow(pv$initial_design))
         pv$initial_design
       }
-      optimize_async_default(inst, self, design, n_workers = pv$n_workers)
+      result = optimize_async_default(inst, self, design, n_workers = pv$n_workers)
+
+      # the workers only update copies of the surrogate, so the final update must happen on the main process
+      tryCatch(
+        {
+          self$surrogate$update()
+        },
+        error = function(error_condition) {
+          lg$warn("Could not update the surrogate a final time after the optimization process has terminated.")
+        }
+      )
+
+      result
     }
   ),
 
@@ -418,17 +430,6 @@ OptimizerAsyncMbo = R6Class(
         # eval
         get_private(inst)$.eval_point(xs)
       }
-
-      on.exit({
-        tryCatch(
-          {
-            self$surrogate$update()
-          },
-          error = function(error_condition) {
-            lg$warn("Could not update the surrogate a final time after the optimization process has terminated.")
-          }
-        )
-      })
     },
 
     .assign_result = function(inst) {

--- a/tests/testthat/test_OptimizerAsyncMbo.R
+++ b/tests/testthat/test_OptimizerAsyncMbo.R
@@ -46,3 +46,23 @@ test_that("OptimizerAsyncMbo works with evaluations in archive", {
   expect_data_table(instance$archive$data[is.na(get("acq_cb"))], min.rows = 10L)
   expect_data_table(instance$archive$data[!is.na(get("acq_cb"))], min.rows = 20L)
 })
+
+test_that("OptimizerAsyncMbo updates the surrogate on the main process after optimization", {
+  rush = start_rush(n_workers = 1)
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
+
+  instance = oi_async(
+    objective = OBJ_2D,
+    search_space = PS_2D,
+    terminator = trm("evals", n_evals = 10L),
+    rush = rush
+  )
+  optimizer = opt("async_mbo", design_function = "sobol", design_size = 5L)
+  optimizer$optimize(instance)
+
+  expect_false(is.null(optimizer$surrogate$learner$model))
+  expect_equal(optimizer$surrogate$learner$state$train_task$nrow, instance$archive$n_finished)
+})


### PR DESCRIPTION
## Summary

- `OptimizerAsyncMbo`'s documented final surrogate update ran only on worker copies inside `bbotk_worker_loop` and was discarded when the worker exited; the user-facing `optimizer$surrogate` on the main session had been `reset()` in `optimize()` and was never updated, while the docs recommend inspecting it after optimization.
- The worker-side `on.exit()` update is removed and a best-effort final update now runs on the main process after `optimize_async_default()` returns, benefiting `OptimizerADBO`, `TunerAsyncMbo`, and `TunerADBO` as well.
- Adds a test asserting that the main-process surrogate is trained on all finished evaluations after optimization.

Stacked on #245 because both change the same exit handler. Addresses R22 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)