### PR TITLE
fix: respect user-supplied components in OptimizerADBO

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * fix: `AcqOptimizerDirect` and `AcqOptimizerLbfgsb` now reset their `state` at the start of each `optimize()` call and clear it on `reset()`, so the `state` no longer grows unboundedly across a Bayesian optimization loop.
 * fix: `AcqOptimizerLbfgsb` now raises a catchable acquisition function optimizer error instead of an unrelated error when no restart produces a valid solution, so the loop function can fall back to a randomly sampled point.
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.
+* fix: `OptimizerADBO` and `TunerADBO` no longer overwrite a user-supplied `surrogate`, `acq_function`, or `acq_optimizer` during optimization; the ADBO defaults are only used for fields that have not been set.
 * fix: `OptimizerADBO` and `TunerADBO` now draw the initial lambda from an exponential distribution as documented, so that the `lambda` parameter has an effect.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
 * fix: `ResultAssignerSurrogate` no longer errors when the archive contains duplicated x-configurations.

--- a/R/OptimizerADBO.R
+++ b/R/OptimizerADBO.R
@@ -19,6 +19,7 @@
 #' `lambda * exp(-rate * (t %% period))`.
 #' The [SurrogateLearner] is configured to use a random forest and
 #' the [AcqOptimizer] is a random search with a batch size of 1000 and a budget of 10000 evaluations.
+#' These defaults are only used for fields that have not been set by the user prior to optimization.
 #'
 #' @section Parameters:
 #' \describe{
@@ -122,19 +123,25 @@ OptimizerADBO = R6Class(
     #' @param inst ([bbotk::OptimInstanceAsyncSingleCrit]).
     #' @return [data.table::data.table()]
     optimize = function(inst) {
-      self$acq_function = AcqFunctionStochasticCB$new(
-        distribution = "exponential",
-        lambda = self$param_set$values$lambda,
-        rate = self$param_set$values$rate,
-        period = self$param_set$values$period
-      )
+      if (is.null(self$acq_function)) {
+        self$acq_function = AcqFunctionStochasticCB$new(
+          distribution = "exponential",
+          lambda = self$param_set$values$lambda,
+          rate = self$param_set$values$rate,
+          period = self$param_set$values$period
+        )
+      }
 
-      self$surrogate = default_surrogate(inst, force_random_forest = TRUE)
+      if (is.null(self$surrogate)) {
+        self$surrogate = default_surrogate(inst, force_random_forest = TRUE)
+      }
 
-      self$acq_optimizer = AcqOptimizer$new(
-        optimizer = opt("random_search", batch_size = 1000L),
-        terminator = trm("evals", n_evals = 10000L)
-      )
+      if (is.null(self$acq_optimizer)) {
+        self$acq_optimizer = AcqOptimizer$new(
+          optimizer = opt("random_search", batch_size = 1000L),
+          terminator = trm("evals", n_evals = 10000L)
+        )
+      }
 
       super$optimize(inst)
     }

--- a/man/mlr_optimizers_adbo.Rd
+++ b/man/mlr_optimizers_adbo.Rd
@@ -22,6 +22,7 @@ ADBO can use periodic exponential decay to reduce lambda periodically for a give
 \code{lambda * exp(-rate * (t \%\% period))}.
 The \link{SurrogateLearner} is configured to use a random forest and
 the \link{AcqOptimizer} is a random search with a batch size of 1000 and a budget of 10000 evaluations.
+These defaults are only used for fields that have not been set by the user prior to optimization.
 }
 \section{Parameters}{
 

--- a/tests/testthat/test_OptimizerADBO.R
+++ b/tests/testthat/test_OptimizerADBO.R
@@ -23,3 +23,28 @@ test_that("OptimizerADBO works in defaults", {
     must.include = c("acq_cb", ".already_evaluated", "acq_lambda_0", "acq_lambda")
   )
 })
+
+test_that("OptimizerADBO does not overwrite user-supplied components", {
+  rush = start_rush(n_workers = 1)
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
+
+  instance = oi_async(
+    objective = OBJ_2D,
+    search_space = PS_2D,
+    terminator = trm("evals", n_evals = 10L),
+    rush = rush
+  )
+  optimizer = opt("adbo", design_function = "sobol", design_size = 5L)
+  surrogate = srlrn(lrn("regr.featureless"))
+  acq_optimizer = acqo(opt("random_search", batch_size = 100L), terminator = trm("evals", n_evals = 100L))
+  optimizer$surrogate = surrogate
+  optimizer$acq_optimizer = acq_optimizer
+
+  optimizer$optimize(instance)
+
+  expect_class(optimizer$surrogate$learner, "LearnerRegrFeatureless")
+  expect_identical(optimizer$acq_optimizer, acq_optimizer)
+})


### PR DESCRIPTION
## Summary

- `OptimizerADBO$optimize()` unconditionally overwrote `surrogate`, `acq_function`, and `acq_optimizer`, although `OptimizerADBO` and `TunerADBO` expose settable active bindings for exactly these fields; user assignments were silently discarded.
- The ADBO defaults are now only applied to fields that are still `NULL`, and the docs state this.
- Adds a test asserting that a user-supplied surrogate and acquisition function optimizer survive optimization.

Addresses R23 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)