### PR TITLE
fix: accept result_assigner in TunerAsyncMbo constructor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
 * fix: `ResultAssignerSurrogate` no longer errors when the archive contains duplicated x-configurations.
 * fix: `srlrn()` now correctly unwraps a single learner supplied in a list instead of erroring.
+* fix: `TunerAsyncMbo` now accepts the documented `result_assigner` construction argument and forwards it to `OptimizerAsyncMbo`.
 * fix: `SurrogateLearner$predict()` no longer modifies the data.table passed as `xdt` by reference.
 
 # mlr3mbo 1.1.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * fix: `AcqOptimizerLbfgsb` now raises a catchable acquisition function optimizer error instead of an unrelated error when no restart produces a valid solution, so the loop function can fall back to a randomly sampled point.
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.
 * fix: `OptimizerADBO` and `TunerADBO` now draw the initial lambda from an exponential distribution as documented, so that the `lambda` parameter has an effect.
+* fix: `OptimizerAsyncMbo` and `TunerAsyncMbo` now raise an informative error when the `param_set` construction argument is not a `ParamSet`.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
 * fix: `ResultAssignerSurrogate` no longer errors when the archive contains duplicated x-configurations.
 * fix: `srlrn()` now correctly unwraps a single learner supplied in a list instead of erroring.

--- a/R/OptimizerAsyncMbo.R
+++ b/R/OptimizerAsyncMbo.R
@@ -149,6 +149,7 @@ OptimizerAsyncMbo = R6Class(
       label = "Asynchronous Model Based Optimization",
       man = "mlr3mbo::OptimizerAsyncMbo"
     ) {
+      assert_r6(param_set, classes = "ParamSet", null.ok = TRUE)
       default_param_set = ps(
         initial_design = p_uty(),
         design_size = p_int(lower = 1, default = 100L),

--- a/R/TunerAsyncMbo.R
+++ b/R/TunerAsyncMbo.R
@@ -89,11 +89,18 @@ TunerAsyncMbo = R6Class(
     #' @template param_result_assigner
     #' @param param_set ([paradox::ParamSet])\cr
     #'  Set of control parameters.
-    initialize = function(surrogate = NULL, acq_function = NULL, acq_optimizer = NULL, param_set = NULL) {
+    initialize = function(
+      surrogate = NULL,
+      acq_function = NULL,
+      acq_optimizer = NULL,
+      result_assigner = NULL,
+      param_set = NULL
+    ) {
       optimizer = OptimizerAsyncMbo$new(
         surrogate = surrogate,
         acq_function = acq_function,
         acq_optimizer = acq_optimizer,
+        result_assigner = result_assigner,
         param_set = param_set
       )
 

--- a/R/TunerAsyncMbo.R
+++ b/R/TunerAsyncMbo.R
@@ -96,6 +96,7 @@ TunerAsyncMbo = R6Class(
       result_assigner = NULL,
       param_set = NULL
     ) {
+      assert_r6(param_set, classes = "ParamSet", null.ok = TRUE)
       optimizer = OptimizerAsyncMbo$new(
         surrogate = surrogate,
         acq_function = acq_function,

--- a/man/mlr_tuners_async_mbo.Rd
+++ b/man/mlr_tuners_async_mbo.Rd
@@ -144,6 +144,7 @@ the respective fields are simply (settable) active bindings to the fields of the
   surrogate = NULL,
   acq_function = NULL,
   acq_optimizer = NULL,
+  result_assigner = NULL,
   param_set = NULL
 )}
     \if{html}{\out{</div>}}
@@ -157,6 +158,8 @@ The surrogate.}
 The acquisition function.}
       \item{\code{acq_optimizer}}{(\link{AcqOptimizer} | \code{NULL})\cr
 The acquisition function optimizer.}
+      \item{\code{result_assigner}}{(\link{ResultAssigner} | \code{NULL})\cr
+The result assigner.}
       \item{\code{param_set}}{(\link[paradox:ParamSet]{paradox::ParamSet})\cr
 Set of control parameters.}
     }

--- a/tests/testthat/test_TunerAsyncMbo.R
+++ b/tests/testthat/test_TunerAsyncMbo.R
@@ -26,3 +26,8 @@ test_that("TunerAsyncMbo works", {
   expect_data_table(instance$archive$data, min.rows = 10L)
   expect_names(names(instance$archive$data), must.include = "acq_cb")
 })
+
+test_that("TunerAsyncMbo accepts a result_assigner during construction", {
+  tuner = tnr("async_mbo", result_assigner = ras("archive"))
+  expect_r6(tuner$result_assigner, classes = "ResultAssignerArchive")
+})


### PR DESCRIPTION
## Summary

- `TunerAsyncMbo` documented a `result_assigner` constructor parameter that did not exist in the signature; `tnr("async_mbo", result_assigner = ...)` errored with "unused argument" while `OptimizerAsyncMbo$new()` accepted it.
- The parameter is now accepted and forwarded to the wrapped `OptimizerAsyncMbo`, with a test asserting the wiring.

Addresses R24 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)