### PR TITLE
fix: assert param_set argument in OptimizerAsyncMbo and TunerAsyncMbo

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * fix: `AcqOptimizerLbfgsb` now raises a catchable acquisition function optimizer error instead of an unrelated error when no restart produces a valid solution, so the loop function can fall back to a randomly sampled point.
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.
 * fix: `OptimizerADBO` and `TunerADBO` now draw the initial lambda from an exponential distribution as documented, so that the `lambda` parameter has an effect.
+* fix: `OptimizerAsyncMbo` and `TunerAsyncMbo` now raise an informative error when the `param_set` construction argument is not a `ParamSet`.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
 * fix: `ResultAssignerSurrogate` no longer errors when the archive contains duplicated x-configurations.
 * fix: `srlrn()` now correctly unwraps a single learner supplied in a list instead of erroring.

--- a/R/OptimizerAsyncMbo.R
+++ b/R/OptimizerAsyncMbo.R
@@ -149,6 +149,7 @@ OptimizerAsyncMbo = R6Class(
       label = "Asynchronous Model Based Optimization",
       man = "mlr3mbo::OptimizerAsyncMbo"
     ) {
+      assert_r6(param_set, classes = "ParamSet", null.ok = TRUE)
       default_param_set = ps(
         initial_design = p_uty(),
         design_size = p_int(lower = 1, default = 100L),

--- a/R/TunerAsyncMbo.R
+++ b/R/TunerAsyncMbo.R
@@ -96,6 +96,7 @@ TunerAsyncMbo = R6Class(
       result_assigner = NULL,
       param_set = NULL
     ) {
+      assert_r6(param_set, classes = "ParamSet", null.ok = TRUE)
       optimizer = OptimizerAsyncMbo$new(
         surrogate = surrogate,
         acq_function = acq_function,

--- a/tests/testthat/test_OptimizerAsyncMbo.R
+++ b/tests/testthat/test_OptimizerAsyncMbo.R
@@ -46,3 +46,8 @@ test_that("OptimizerAsyncMbo works with evaluations in archive", {
   expect_data_table(instance$archive$data[is.na(get("acq_cb"))], min.rows = 10L)
   expect_data_table(instance$archive$data[!is.na(get("acq_cb"))], min.rows = 20L)
 })
+
+test_that("OptimizerAsyncMbo asserts the param_set argument", {
+  expect_error(OptimizerAsyncMbo$new(param_set = "foo"), "param_set")
+  expect_error(TunerAsyncMbo$new(param_set = "foo"), "param_set")
+})

--- a/tests/testthat/test_OptimizerAsyncMbo.R
+++ b/tests/testthat/test_OptimizerAsyncMbo.R
@@ -46,8 +46,3 @@ test_that("OptimizerAsyncMbo works with evaluations in archive", {
   expect_data_table(instance$archive$data[is.na(get("acq_cb"))], min.rows = 10L)
   expect_data_table(instance$archive$data[!is.na(get("acq_cb"))], min.rows = 20L)
 })
-
-test_that("OptimizerAsyncMbo asserts the param_set argument", {
-  expect_error(OptimizerAsyncMbo$new(param_set = "foo"), "param_set")
-  expect_error(TunerAsyncMbo$new(param_set = "foo"), "param_set")
-})


### PR DESCRIPTION
## Summary

- The user-facing `param_set` construction argument of `OptimizerAsyncMbo` and `TunerAsyncMbo` had no checkmate assertion; a non-`ParamSet` value failed deep inside paradox's `c()` with a confusing message.
- Both constructors now validate the argument with `assert_r6(param_set, classes = "ParamSet", null.ok = TRUE)`.

Stacked on #248 because both change the `TunerAsyncMbo` constructor. Addresses R25 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)