### PR TITLE
docs: document lambda, rate, and period parameters of TunerADBO

### DIFF
--- a/R/TunerADBO.R
+++ b/R/TunerADBO.R
@@ -13,6 +13,12 @@
 #'
 #' @section Parameters:
 #' \describe{
+#' \item{`lambda`}{`numeric(1)`\cr
+#'   Value used for sampling the lambda for each worker from an exponential distribution.}
+#' \item{`rate`}{`numeric(1)`\cr
+#'   Rate of the exponential decay.}
+#' \item{`period`}{`integer(1)`\cr
+#'   Period of the exponential decay.}
 #' \item{`initial_design`}{`data.table::data.table()`\cr
 #'   Initial design of the optimization.
 #'   If `NULL`, a design of size `design_size` is generated with the specified `design_function`.

--- a/man/mlr_tuners_adbo.Rd
+++ b/man/mlr_tuners_adbo.Rd
@@ -17,6 +17,12 @@ Currently, only single-objective optimization is supported and
 \section{Parameters}{
 
 \describe{
+\item{\code{lambda}}{\code{numeric(1)}\cr
+Value used for sampling the lambda for each worker from an exponential distribution.}
+\item{\code{rate}}{\code{numeric(1)}\cr
+Rate of the exponential decay.}
+\item{\code{period}}{\code{integer(1)}\cr
+Period of the exponential decay.}
 \item{\code{initial_design}}{\code{data.table::data.table()}\cr
 Initial design of the optimization.
 If \code{NULL}, a design of size \code{design_size} is generated with the specified \code{design_function}.


### PR DESCRIPTION
## Summary

- The "Parameters" section of `TunerADBO` omitted `lambda`, `rate`, and `period`, which are part of the inherited parameter set, so users of `tnr("adbo")` could not discover the decay parameters.
- The three entries are copied from the `OptimizerADBO` documentation.

Addresses R26 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)