### PR TITLE
fix: always return a data.table from SurrogateLearner$predict()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@
 * fix: `ResultAssignerSurrogate` no longer errors when the archive contains duplicated x-configurations.
 * fix: `srlrn()` now correctly unwraps a single learner supplied in a list instead of erroring.
 * fix: `SurrogateLearner$predict()` no longer modifies the data.table passed as `xdt` by reference.
+* fix: `SurrogateLearner$predict()` now always returns a `data.table` with columns `mean` and `se` as documented, instead of a bare named list in configurations without an inverting output transformation.
 
 # mlr3mbo 1.1.1
 

--- a/R/SurrogateLearner.R
+++ b/R/SurrogateLearner.R
@@ -148,8 +148,9 @@ SurrogateLearner = R6Class(
         }
       }
 
+      pred = as.data.table(pred)
       if (!is.null(self$output_trafo) && self$output_trafo$invert_posterior) {
-        pred = self$output_trafo$inverse_transform_posterior(as.data.table(pred))
+        pred = self$output_trafo$inverse_transform_posterior(pred)
       }
       pred
     }

--- a/tests/testthat/test_SurrogateLearner.R
+++ b/tests/testthat/test_SurrogateLearner.R
@@ -11,7 +11,7 @@ test_that("SurrogateLearner API works", {
 
   xdt = data.table(x = seq(-1, 1, length.out = 5L))
   pred = surrogate$predict(xdt)
-  expect_list(pred, len = 2L)
+  expect_data_table(pred, ncols = 2L, nrows = 5L)
   expect_names(names(pred), identical.to = c("mean", "se"))
   expect_numeric(pred$mean, len = 5L)
   expect_numeric(pred$se, len = 5L)


### PR DESCRIPTION
## Summary

- `SurrogateLearner$predict()` documented a `data.table` return with columns `mean` and `se` but returned a bare named list unless an output trafo with `invert_posterior = TRUE` was configured.
- The prediction is now converted to a `data.table` on every path, and the shape test asserts the documented type.
- All internal consumers access the prediction via `$mean`/`$se`, which behaves identically on a `data.table`.

Addresses R27 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)