### PR TITLE
fix: validate learner and trafo assignments in surrogate classes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@
 * fix: `ResultAssignerSurrogate` no longer errors when the archive contains duplicated x-configurations.
 * fix: `srlrn()` now correctly unwraps a single learner supplied in a list instead of erroring.
 * fix: `SurrogateLearner$predict()` no longer modifies the data.table passed as `xdt` by reference.
+* fix: `SurrogateLearner` and `SurrogateLearnerCollection` now validate assignments to the `learner`, `input_trafo`, and `output_trafo` fields, so invalid values are rejected immediately instead of failing later during updating or predicting.
 
 # mlr3mbo 1.1.1
 

--- a/R/Surrogate.R
+++ b/R/Surrogate.R
@@ -9,10 +9,6 @@
 Surrogate = R6Class(
   "Surrogate",
   public = list(
-    #' @field learner (learner)\cr
-    #'   Arbitrary learner object depending on the subclass.
-    learner = NULL,
-
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
     #'
@@ -103,6 +99,17 @@ Surrogate = R6Class(
   ),
 
   active = list(
+    #' @field learner (learner)\cr
+    #'   Arbitrary learner object depending on the subclass.
+    #'   Subclasses validate the learner on assignment.
+    learner = function(rhs) {
+      if (missing(rhs)) {
+        private$.learner
+      } else {
+        private$.learner = rhs
+      }
+    },
+
     #' @template field_print_id
     print_id = function(rhs) {
       if (missing(rhs)) {
@@ -202,6 +209,8 @@ Surrogate = R6Class(
   ),
 
   private = list(
+    .learner = NULL,
+
     .archive = NULL,
 
     .cols_x = NULL,

--- a/R/SurrogateLearner.R
+++ b/R/SurrogateLearner.R
@@ -57,18 +57,6 @@ SurrogateLearner = R6Class(
   inherit = Surrogate,
 
   public = list(
-    #' @field learner ([mlr3::LearnerRegr])\cr
-    #'   [mlr3::LearnerRegr] wrapped as a surrogate model.
-    learner = NULL,
-
-    #' @field input_trafo ([InputTrafo])\cr
-    #'   Input transformation.
-    input_trafo = NULL,
-
-    #' @field output_trafo ([OutputTrafo])\cr
-    #'   Output transformation.
-    output_trafo = NULL,
-
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
     #'
@@ -91,9 +79,9 @@ SurrogateLearner = R6Class(
         learner$predict_type = "se"
       }
 
-      self$input_trafo = assert_r6(input_trafo, classes = "InputTrafo", null.ok = TRUE)
+      self$input_trafo = input_trafo
 
-      self$output_trafo = assert_r6(output_trafo, classes = "OutputTrafo", null.ok = TRUE)
+      self$output_trafo = output_trafo
 
       assert_r6(archive, classes = "Archive", null.ok = TRUE)
 
@@ -106,11 +94,6 @@ SurrogateLearner = R6Class(
       )
       ps$values = list(catch_errors = TRUE, impute_method = "random")
 
-      private$.predict_names = if (learner$predict_type == "se") {
-        c("mean", "se")
-      } else {
-        "mean"
-      }
       super$initialize(learner = learner, archive = archive, cols_x = cols_x, cols_y = col_y, param_set = ps)
     },
 
@@ -156,6 +139,37 @@ SurrogateLearner = R6Class(
   ),
 
   active = list(
+    #' @field learner ([mlr3::LearnerRegr])\cr
+    #'   [mlr3::LearnerRegr] wrapped as a surrogate model.
+    learner = function(rhs) {
+      if (missing(rhs)) {
+        return(private$.learner)
+      }
+      assert_learner(rhs)
+      private$.learner = rhs
+      private$.predict_names = if (rhs$predict_type == "se") c("mean", "se") else "mean"
+    },
+
+    #' @field input_trafo ([InputTrafo] | `NULL`)\cr
+    #'   Input transformation.
+    input_trafo = function(rhs) {
+      if (missing(rhs)) {
+        private$.input_trafo
+      } else {
+        private$.input_trafo = assert_r6(rhs, classes = "InputTrafo", null.ok = TRUE)
+      }
+    },
+
+    #' @field output_trafo ([OutputTrafo] | `NULL`)\cr
+    #'   Output transformation.
+    output_trafo = function(rhs) {
+      if (missing(rhs)) {
+        private$.output_trafo
+      } else {
+        private$.output_trafo = assert_r6(rhs, classes = "OutputTrafo", null.ok = TRUE)
+      }
+    },
+
     #' @template field_print_id
     print_id = function(rhs) {
       if (missing(rhs)) {
@@ -285,14 +299,18 @@ SurrogateLearner = R6Class(
     deep_clone = function(name, value) {
       switch(
         name,
-        learner = value$clone(deep = TRUE),
-        input_trafo = if (is.null(value)) value else value$clone(deep = TRUE),
-        output_trafo = if (is.null(value)) value else value$clone(deep = TRUE),
+        .learner = value$clone(deep = TRUE),
+        .input_trafo = if (is.null(value)) value else value$clone(deep = TRUE),
+        .output_trafo = if (is.null(value)) value else value$clone(deep = TRUE),
         .param_set = value$clone(deep = TRUE),
         .archive = value$clone(deep = TRUE),
         value
       )
     },
+
+    .input_trafo = NULL,
+
+    .output_trafo = NULL,
 
     .predict_names = NULL
   )

--- a/R/SurrogateLearnerCollection.R
+++ b/R/SurrogateLearnerCollection.R
@@ -66,18 +66,6 @@ SurrogateLearnerCollection = R6Class(
   inherit = Surrogate,
 
   public = list(
-    #' @field learner (list of [mlr3::LearnerRegr])\cr
-    #'   List of [mlr3::LearnerRegr] wrapped as surrogate models.
-    learner = NULL,
-
-    #' @field input_trafo ([InputTrafo])\cr
-    #'   Input transformation.
-    input_trafo = NULL,
-
-    #' @field output_trafo ([OutputTrafo])\cr
-    #'   Output transformation.
-    output_trafo = NULL,
-
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
     #'
@@ -96,20 +84,15 @@ SurrogateLearnerCollection = R6Class(
       cols_y = NULL
     ) {
       assert_learners(learners)
-      addresses = map(learners, address)
-      if (length(unique(addresses)) != length(addresses)) {
-        stop("Redundant Learners must be unique in memory, i.e., deep clones.")
-      }
-      assert_learners(learners)
       for (learner in learners) {
         if (learner$predict_type != "se" && "se" %in% learner$predict_types) {
           learner$predict_type = "se"
         }
       }
 
-      self$input_trafo = assert_r6(input_trafo, classes = "InputTrafo", null.ok = TRUE)
+      self$input_trafo = input_trafo
 
-      self$output_trafo = assert_r6(output_trafo, classes = "OutputTrafo", null.ok = TRUE)
+      self$output_trafo = output_trafo
 
       assert_r6(archive, classes = "Archive", null.ok = TRUE)
 
@@ -176,6 +159,41 @@ SurrogateLearnerCollection = R6Class(
   ),
 
   active = list(
+    #' @field learner (list of [mlr3::LearnerRegr])\cr
+    #'   List of [mlr3::LearnerRegr] wrapped as surrogate models.
+    #'   The learners must be unique in memory, i.e., deep clones.
+    learner = function(rhs) {
+      if (missing(rhs)) {
+        return(private$.learner)
+      }
+      assert_learners(rhs)
+      addresses = map(rhs, address)
+      if (length(unique(addresses)) != length(addresses)) {
+        stop("Redundant Learners must be unique in memory, i.e., deep clones.")
+      }
+      private$.learner = rhs
+    },
+
+    #' @field input_trafo ([InputTrafo] | `NULL`)\cr
+    #'   Input transformation.
+    input_trafo = function(rhs) {
+      if (missing(rhs)) {
+        private$.input_trafo
+      } else {
+        private$.input_trafo = assert_r6(rhs, classes = "InputTrafo", null.ok = TRUE)
+      }
+    },
+
+    #' @field output_trafo ([OutputTrafo] | `NULL`)\cr
+    #'   Output transformation.
+    output_trafo = function(rhs) {
+      if (missing(rhs)) {
+        private$.output_trafo
+      } else {
+        private$.output_trafo = assert_r6(rhs, classes = "OutputTrafo", null.ok = TRUE)
+      }
+    },
+
     #' @template field_print_id
     print_id = function(rhs) {
       if (missing(rhs)) {
@@ -364,13 +382,17 @@ SurrogateLearnerCollection = R6Class(
     deep_clone = function(name, value) {
       switch(
         name,
-        learner = map(value, function(x) x$clone(deep = TRUE)),
-        input_trafo = if (is.null(value)) value else value$clone(deep = TRUE),
-        output_trafo = if (is.null(value)) value else value$clone(deep = TRUE),
+        .learner = map(value, function(x) x$clone(deep = TRUE)),
+        .input_trafo = if (is.null(value)) value else value$clone(deep = TRUE),
+        .output_trafo = if (is.null(value)) value else value$clone(deep = TRUE),
         .param_set = value$clone(deep = TRUE),
         .archive = value$clone(deep = TRUE),
         value
       )
-    }
+    },
+
+    .input_trafo = NULL,
+
+    .output_trafo = NULL
   )
 )

--- a/man/Surrogate.Rd
+++ b/man/Surrogate.Rd
@@ -8,17 +8,13 @@ Abstract surrogate model class.
 
 A surrogate model is used to model the unknown objective function(s) based on all points evaluated so far.
 }
-\section{Public fields}{
-  \if{html}{\out{<div class="r6-fields">}}
-  \describe{
-    \item{\code{learner}}{(learner)\cr
-Arbitrary learner object depending on the subclass.}
-  }
-  \if{html}{\out{</div>}}
-}
 \section{Active bindings}{
   \if{html}{\out{<div class="r6-active-bindings">}}
   \describe{
+    \item{\code{learner}}{(learner)\cr
+Arbitrary learner object depending on the subclass.
+Subclasses validate the learner on assignment.}
+
     \item{\code{print_id}}{(\code{character})\cr
 Id used when printing.}
 

--- a/man/SurrogateLearner.Rd
+++ b/man/SurrogateLearner.Rd
@@ -60,23 +60,18 @@ if (requireNamespace("mlr3learners") &
 \section{Super class}{
 \code{\link[mlr3mbo:Surrogate]{Surrogate}} -> \code{SurrogateLearner}
 }
-\section{Public fields}{
-  \if{html}{\out{<div class="r6-fields">}}
+\section{Active bindings}{
+  \if{html}{\out{<div class="r6-active-bindings">}}
   \describe{
     \item{\code{learner}}{(\link[mlr3:LearnerRegr]{mlr3::LearnerRegr})\cr
 \link[mlr3:LearnerRegr]{mlr3::LearnerRegr} wrapped as a surrogate model.}
 
-    \item{\code{input_trafo}}{(\link{InputTrafo})\cr
+    \item{\code{input_trafo}}{(\link{InputTrafo} | \code{NULL})\cr
 Input transformation.}
 
-    \item{\code{output_trafo}}{(\link{OutputTrafo})\cr
+    \item{\code{output_trafo}}{(\link{OutputTrafo} | \code{NULL})\cr
 Output transformation.}
-  }
-  \if{html}{\out{</div>}}
-}
-\section{Active bindings}{
-  \if{html}{\out{<div class="r6-active-bindings">}}
-  \describe{
+
     \item{\code{print_id}}{(\code{character})\cr
 Id used when printing.}
 

--- a/man/SurrogateLearnerCollection.Rd
+++ b/man/SurrogateLearnerCollection.Rd
@@ -69,23 +69,19 @@ if (requireNamespace("mlr3learners") &
 \section{Super class}{
 \code{\link[mlr3mbo:Surrogate]{Surrogate}} -> \code{SurrogateLearnerCollection}
 }
-\section{Public fields}{
-  \if{html}{\out{<div class="r6-fields">}}
-  \describe{
-    \item{\code{learner}}{(list of \link[mlr3:LearnerRegr]{mlr3::LearnerRegr})\cr
-List of \link[mlr3:LearnerRegr]{mlr3::LearnerRegr} wrapped as surrogate models.}
-
-    \item{\code{input_trafo}}{(\link{InputTrafo})\cr
-Input transformation.}
-
-    \item{\code{output_trafo}}{(\link{OutputTrafo})\cr
-Output transformation.}
-  }
-  \if{html}{\out{</div>}}
-}
 \section{Active bindings}{
   \if{html}{\out{<div class="r6-active-bindings">}}
   \describe{
+    \item{\code{learner}}{(list of \link[mlr3:LearnerRegr]{mlr3::LearnerRegr})\cr
+List of \link[mlr3:LearnerRegr]{mlr3::LearnerRegr} wrapped as surrogate models.
+The learners must be unique in memory, i.e., deep clones.}
+
+    \item{\code{input_trafo}}{(\link{InputTrafo} | \code{NULL})\cr
+Input transformation.}
+
+    \item{\code{output_trafo}}{(\link{OutputTrafo} | \code{NULL})\cr
+Output transformation.}
+
     \item{\code{print_id}}{(\code{character})\cr
 Id used when printing.}
 

--- a/tests/testthat/test_SurrogateLearner.R
+++ b/tests/testthat/test_SurrogateLearner.R
@@ -107,3 +107,18 @@ test_that("feature types", {
   surrogate = SurrogateLearner$new(learner = REGR_KM_DETERM)
   expect_equal(surrogate$feature_types, surrogate$learner$feature_types)
 })
+
+test_that("SurrogateLearner fields are validated on assignment", {
+  inst = MAKE_INST_1D()
+  surrogate = SurrogateLearner$new(learner = REGR_FEATURELESS$clone(deep = TRUE), archive = inst$archive)
+  expect_error({surrogate$learner = "garbage"}, "Learner")
+  expect_error({surrogate$input_trafo = "garbage"}, "R6")
+  expect_error({surrogate$output_trafo = "garbage"}, "R6")
+  surrogate$output_trafo = OutputTrafoStandardize$new()
+  expect_r6(surrogate$output_trafo, "OutputTrafoStandardize")
+  surrogate$output_trafo = NULL
+  expect_null(surrogate$output_trafo)
+  learner = lrn("regr.featureless")
+  surrogate$learner = learner
+  expect_identical(surrogate$learner, learner)
+})

--- a/tests/testthat/test_SurrogateLearnerCollection.R
+++ b/tests/testthat/test_SurrogateLearnerCollection.R
@@ -119,3 +119,14 @@ test_that("feature types", {
   surrogate = SurrogateLearnerCollection$new(learners = list(REGR_KM_DETERM, REGR_FEATURELESS))
   expect_equal(surrogate$feature_types, Reduce(intersect, map(surrogate$learner, "feature_types")))
 })
+
+test_that("SurrogateLearnerCollection fields are validated on assignment", {
+  surrogate = SurrogateLearnerCollection$new(
+    learners = list(REGR_FEATURELESS$clone(deep = TRUE), REGR_FEATURELESS$clone(deep = TRUE))
+  )
+  expect_error({surrogate$learner = "garbage"}, "list")
+  learner = REGR_FEATURELESS$clone(deep = TRUE)
+  expect_error({surrogate$learner = list(learner, learner)}, "unique in memory")
+  expect_error({surrogate$input_trafo = "garbage"}, "R6")
+  expect_error({surrogate$output_trafo = "garbage"}, "R6")
+})


### PR DESCRIPTION
## Summary

- `learner`, `input_trafo`, and `output_trafo` were raw public fields on `SurrogateLearner` and `SurrogateLearnerCollection` with no assignment validation (`s$output_trafo = "garbage"` was accepted silently), violating the project's active-binding convention.
- All three are now validated active bindings backed by private fields. The base class `Surrogate` stores the learner in `private$.learner` with a permissive binding that subclasses override.
- `SurrogateLearnerCollection`'s binding also enforces the unique-in-memory requirement for redundant learners; the predict-type upgrade to `"se"` stays constructor-only so that intentionally downgrading a learner's predict type keeps working.
- `SurrogateLearner` keeps its internal predict names in sync when a new learner is assigned.
- Deep-clone behavior is preserved via the renamed private fields.

Addresses R28 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)