### PR TITLE
fix: floor OutputTrafoLog epsilon padding at the local ULP scale

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.
 * fix: `OptimizerADBO` and `TunerADBO` now draw the initial lambda from an exponential distribution as documented, so that the `lambda` parameter has an effect.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
+* fix: `OutputTrafoLog` no longer produces infinite values when the range of the observed outcomes is tiny relative to their magnitude, because the epsilon padding is now floored at the local floating point precision.
 * fix: `ResultAssignerSurrogate` no longer errors when the archive contains duplicated x-configurations.
 * fix: `srlrn()` now correctly unwraps a single learner supplied in a list instead of erroring.
 * fix: `SurrogateLearner$predict()` no longer modifies the data.table passed as `xdt` by reference.

--- a/R/OutputTrafoLog.R
+++ b/R/OutputTrafoLog.R
@@ -70,10 +70,15 @@ OutputTrafoLog = R6Class(
     update = function(ydt) {
       epsilon = 1e-3
       state = map(self$cols_y, function(col_y) {
-        range_y = diff(range(ydt[[col_y]]))
+        min_y = min(ydt[[col_y]])
+        max_y = max(ydt[[col_y]])
+        range_y = max_y - min_y
         # if all values are identical, a relative epsilon would result in min == max and transform() would yield NaN
         epsilon_extended = if (range_y == 0) epsilon * max(1, abs(ydt[[col_y]][1L])) else epsilon * range_y
-        list(min = min(ydt[[col_y]]) - epsilon_extended, max = max(ydt[[col_y]]) + epsilon_extended, epsilon = epsilon)
+        # floor the padding at the local ULP scale so that it does not vanish in double precision
+        # when the range is tiny relative to the magnitude of the outcomes
+        epsilon_extended = max(epsilon_extended, 4 * .Machine$double.eps * max(abs(min_y), abs(max_y), 1))
+        list(min = min_y - epsilon_extended, max = max_y + epsilon_extended, epsilon = epsilon)
       })
       state = setNames(state, nm = self$cols_y)
       private$.state = state

--- a/tests/testthat/test_OutputTrafoLog.R
+++ b/tests/testthat/test_OutputTrafoLog.R
@@ -44,6 +44,22 @@ test_that("OutputTrafoLog works with constant y values", {
   expect_equal(ot$inverse_transform(transformed_data), ydt)
 })
 
+test_that("OutputTrafoLog works with tiny relative ranges", {
+  ot = OutputTrafoLog$new()
+  ot$cols_y = "y"
+  ydt = data.table(y = c(1e12, 1e12 + 1e-3))
+
+  ot$max_to_min = c(y = 1L)
+  ot$update(ydt)
+  transformed_data = ot$transform(ydt)
+  expect_true(all(is.finite(transformed_data$y)))
+
+  ot$max_to_min = c(y = -1L)
+  ot$update(ydt)
+  transformed_data = ot$transform(ydt)
+  expect_true(all(is.finite(transformed_data$y)))
+})
+
 test_that("OutputTrafoLog works with SurrogateLearner", {
   skip_if_missing_regr_km()
   instance = MAKE_INST_1D()


### PR DESCRIPTION
## Summary

- The constant-outcome fix for `OutputTrafoLog` only handled `range_y == 0` exactly. For tiny but nonzero relative ranges (e.g., `y = c(1e12, 1e12 + 1e-3)`), the epsilon padding vanished in double precision and `transform()` still returned `-Inf`/`+Inf`, poisoning surrogate training.
- The padding is now floored at four times the local ULP scale, so the padded minimum and maximum are always representable as distinct doubles.
- Adds a regression test covering both optimization directions.

Addresses R30 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)