### PR TITLE
fix: handle mean-only predictions in OutputTrafoLog posterior inversion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.
 * fix: `OptimizerADBO` and `TunerADBO` now draw the initial lambda from an exponential distribution as documented, so that the `lambda` parameter has an effect.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
+* fix: `OutputTrafoLog$inverse_transform_posterior()` no longer errors on mean-only predictions of a response-only learner; the mean is inverted with a variance of zero and no `se` column is fabricated.
 * fix: `ResultAssignerSurrogate` no longer errors when the archive contains duplicated x-configurations.
 * fix: `srlrn()` now correctly unwraps a single learner supplied in a list instead of erroring.
 * fix: `SurrogateLearner$predict()` no longer modifies the data.table passed as `xdt` by reference.

--- a/R/OutputTrafoLog.R
+++ b/R/OutputTrafoLog.R
@@ -144,23 +144,28 @@ OutputTrafoLog = R6Class(
         }
       }
       for (col_y in self$cols_y) {
+        # mean-only predictions of a response-only learner are inverted with a variance of zero
+        has_se = "se" %in% colnames(pred[[col_y]])
+        variance = if (has_se) pred[[col_y]]$se^2 else 0
         if (self$max_to_min[[col_y]] == 1L) {
           mean = (self$state[[col_y]]$max - self$state[[col_y]]$min) *
-            exp(pred[[col_y]]$mean + ((pred[[col_y]]$se^2) / 2)) +
+            exp(pred[[col_y]]$mean + (variance / 2)) +
             self$state[[col_y]]$min
           se = (self$state[[col_y]]$max - self$state[[col_y]]$min) *
-            exp(pred[[col_y]]$mean + ((pred[[col_y]]$se^2) / 2)) *
-            sqrt(expm1(pred[[col_y]]$se^2))
+            exp(pred[[col_y]]$mean + (variance / 2)) *
+            sqrt(expm1(variance))
         } else {
           mean = -(self$state[[col_y]]$max - self$state[[col_y]]$min) *
-            exp(-pred[[col_y]]$mean + ((pred[[col_y]]$se^2) / 2)) +
+            exp(-pred[[col_y]]$mean + (variance / 2)) +
             self$state[[col_y]]$max
           se = (self$state[[col_y]]$max - self$state[[col_y]]$min) *
-            exp(-pred[[col_y]]$mean + ((pred[[col_y]]$se^2) / 2)) *
-            sqrt(expm1(pred[[col_y]]$se^2))
+            exp(-pred[[col_y]]$mean + (variance / 2)) *
+            sqrt(expm1(variance))
         }
         set(pred[[col_y]], j = "mean", value = mean)
-        set(pred[[col_y]], j = "se", value = se)
+        if (has_se) {
+          set(pred[[col_y]], j = "se", value = se)
+        }
       }
       if (length(self$cols_y) == 1L) {
         pred[[self$cols_y]]

--- a/tests/testthat/test_OutputTrafoLog.R
+++ b/tests/testthat/test_OutputTrafoLog.R
@@ -172,3 +172,23 @@ test_that("OutputTrafoLog works with OptimizerMbo and bayesopt_smsego", {
   expect_true(nrow(instance$archive$data) == 5L)
   expect_data_table(instance$result, min.rows = 1L)
 })
+
+test_that("OutputTrafoLog inverse_transform_posterior works with mean-only predictions", {
+  ot = OutputTrafoLog$new()
+  ot$cols_y = "y"
+  ydt = data.table(y = c(1, 2, 3))
+
+  ot$max_to_min = c(y = 1L)
+  ot$update(ydt)
+  pred = data.table(mean = ot$transform(ydt)$y)
+  inverted = ot$inverse_transform_posterior(pred)
+  expect_data_table(inverted, nrows = 3L)
+  expect_equal(inverted$mean, ydt$y)
+  expect_false("se" %in% names(inverted))
+
+  ot$max_to_min = c(y = -1L)
+  ot$update(ydt)
+  pred = data.table(mean = ot$transform(ydt)$y)
+  inverted = ot$inverse_transform_posterior(pred)
+  expect_equal(inverted$mean, ydt$y)
+})


### PR DESCRIPTION
## Summary

- `OutputTrafoLog$inverse_transform_posterior()` crashed on mean-only predictions (response-only learner, an explicitly supported configuration): `pred[[col_y]]$se` is `NULL`, `NULL^2` is `numeric(0)`, and `set()` died with a cryptic data.table error.
- The mean is now inverted with a variance of zero (the lognormal mean inversion then coincides with `inverse_transform()`), and no `se` column is fabricated.
- Adds a test covering both optimization directions.

Addresses R31 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)