### PR TITLE
fix: skip absent se column in OutputTrafoStandardize posterior inversion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.
 * fix: `OptimizerADBO` and `TunerADBO` now draw the initial lambda from an exponential distribution as documented, so that the `lambda` parameter has an effect.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
+* fix: `OutputTrafoStandardize$inverse_transform_posterior()` no longer fabricates an all-`NA` `se` column for mean-only predictions of a response-only learner.
 * fix: `ResultAssignerSurrogate` no longer errors when the archive contains duplicated x-configurations.
 * fix: `srlrn()` now correctly unwraps a single learner supplied in a list instead of erroring.
 * fix: `SurrogateLearner$predict()` no longer modifies the data.table passed as `xdt` by reference.

--- a/R/OutputTrafoStandardize.R
+++ b/R/OutputTrafoStandardize.R
@@ -132,9 +132,12 @@ OutputTrafoStandardize = R6Class(
       }
       for (col_y in self$cols_y) {
         mean = pred[[col_y]]$mean * self$state[[col_y]]$sigma + self$state[[col_y]]$mu
-        se = pred[[col_y]]$se * self$state[[col_y]]$sigma
         set(pred[[col_y]], j = "mean", value = mean)
-        set(pred[[col_y]], j = "se", value = se)
+        # mean-only predictions of a response-only learner have no se column to invert
+        if ("se" %in% colnames(pred[[col_y]])) {
+          se = pred[[col_y]]$se * self$state[[col_y]]$sigma
+          set(pred[[col_y]], j = "se", value = se)
+        }
       }
       if (length(self$cols_y) == 1L) {
         pred[[self$cols_y]]

--- a/tests/testthat/test_OutputTrafoStandardize.R
+++ b/tests/testthat/test_OutputTrafoStandardize.R
@@ -150,3 +150,16 @@ test_that("OutputTrafoStandardize works with OptimizerMbo and bayesopt_smsego", 
   expect_true(nrow(instance$archive$data) == 5L)
   expect_data_table(instance$result, min.rows = 1L)
 })
+
+test_that("OutputTrafoStandardize inverse_transform_posterior works with mean-only predictions", {
+  ot = OutputTrafoStandardize$new()
+  ot$cols_y = "y"
+  ot$max_to_min = c(y = 1L)
+  ydt = data.table(y = c(1, 2, 3))
+  ot$update(ydt)
+  pred = data.table(mean = ot$transform(ydt)$y)
+  inverted = ot$inverse_transform_posterior(pred)
+  expect_data_table(inverted, nrows = 3L)
+  expect_equal(inverted$mean, ydt$y)
+  expect_false("se" %in% names(inverted))
+})


### PR DESCRIPTION
## Summary

- For mean-only predictions of a response-only learner (an explicitly supported configuration), `OutputTrafoStandardize$inverse_transform_posterior()` silently fabricated an all-`NA` `se` column because `pred[[col_y]]$se` is `NULL`.
- The mean inversion of the standardize trafo is se-free, so the `se` column is now only inverted when present.
- Adds a regression test.

Addresses R32 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)