### PR TITLE
fix: guard degenerate and infinite bounds in InputTrafoUnitcube

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * fix: `AcqOptimizerDirect` and `AcqOptimizerLbfgsb` now reset their `state` at the start of each `optimize()` call and clear it on `reset()`, so the `state` no longer grows unboundedly across a Bayesian optimization loop.
 * fix: `AcqOptimizerLbfgsb` now raises a catchable acquisition function optimizer error instead of an unrelated error when no restart produces a valid solution, so the loop function can fall back to a randomly sampled point.
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.
+* fix: `InputTrafoUnitcube` now raises an informative error for infinite bounds and maps degenerate parameters with equal lower and upper bounds to a constant, instead of producing `NaN` features that fail inside the surrogate learner.
 * fix: `OptimizerADBO` and `TunerADBO` now draw the initial lambda from an exponential distribution as documented, so that the `lambda` parameter has an effect.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
 * fix: `ResultAssignerSurrogate` no longer errors when the archive contains duplicated x-configurations.

--- a/R/InputTrafoUnitcube.R
+++ b/R/InputTrafoUnitcube.R
@@ -61,6 +61,14 @@ InputTrafoUnitcube = R6Class(
     #' @param xdt ([data.table::data.table()])\cr
     #'   Data. One row per observation with at least columns `$cols_x`.
     update = function(xdt) {
+      parameters = names(which(self$search_space$is_number)) # numeric or integer
+      bounds_finite = is.finite(self$search_space$lower[parameters]) & is.finite(self$search_space$upper[parameters])
+      if (!all(bounds_finite)) {
+        error_config(
+          "InputTrafoUnitcube requires finite bounds for all numeric parameters but the bounds of '%s' are not finite.",
+          str_collapse(names(which(!bounds_finite)))
+        )
+      }
       private$.state = list()
     },
 
@@ -80,12 +88,15 @@ InputTrafoUnitcube = R6Class(
       parameters = names(which(self$search_space$is_number)) # numeric or integer
       assert_subset(parameters, self$cols_x)
       for (parameter in parameters) {
-        set(
-          xdt,
-          j = parameter,
-          value = (xdt[[parameter]] - self$search_space$lower[[parameter]]) /
-            (self$search_space$upper[[parameter]] - self$search_space$lower[[parameter]])
-        )
+        lower = self$search_space$lower[[parameter]]
+        upper = self$search_space$upper[[parameter]]
+        # a degenerate dimension carries no information and is mapped to the center of the unit interval
+        value = if (lower == upper) {
+          rep(0.5, nrow(xdt))
+        } else {
+          (xdt[[parameter]] - lower) / (upper - lower)
+        }
+        set(xdt, j = parameter, value = value)
       }
       xdt
     }

--- a/tests/testthat/test_InputTrafoUnitcube.R
+++ b/tests/testthat/test_InputTrafoUnitcube.R
@@ -112,3 +112,19 @@ test_that("InputTrafoUnitcube works with OptimizerMbo and bayesopt_smsego", {
   expect_true(nrow(instance$archive$data) == 5L)
   expect_data_table(instance$result, min.rows = 1L)
 })
+
+test_that("InputTrafoUnitcube handles degenerate and infinite bounds", {
+  it = InputTrafoUnitcube$new()
+  it$cols_x = c("x1", "x2")
+  it$search_space = ps(x1 = p_dbl(-1, 1), x2 = p_dbl(1, 1))
+  xdt = data.table(x1 = c(-1, 0, 1), x2 = c(1, 1, 1))
+  it$update(xdt)
+  transformed = it$transform(xdt)
+  expect_equal(transformed$x1, c(0, 0.5, 1))
+  expect_equal(transformed$x2, rep(0.5, 3L))
+
+  it = InputTrafoUnitcube$new()
+  it$cols_x = "x"
+  it$search_space = ps(x = p_dbl())
+  expect_error(it$update(data.table(x = 1)), "finite")
+})


### PR DESCRIPTION
## Summary

- `InputTrafoUnitcube` had no guard for degenerate (`lower == upper`, legal in paradox) or infinite bounds: min-max scaling produced `0/0 = NaN` or infinite features that failed inside the surrogate learner far from the cause.
- Degenerate parameters are now mapped to the constant `0.5` (center of the unit interval), and infinite bounds raise an informative `error_config()` in `update()`.
- Adds tests for both cases.

Addresses R34 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)