### PR TITLE
fix: restore Sobol initial design in bayesopt_ego

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # mlr3mbo (development version)
 
 * fix: `AcqOptimizer` and its subclasses gained `$label` and `$man` fields, so that `as.data.table(mlr_acqoptimizers)` no longer errors.
+* fix: `bayesopt_ego()` again generates its initial design via a Sobol sequence as documented, consistent with all other loop functions.
 * fix: `AcqFunctionAEI` no longer errors during `$update()` when the surrogate model is not a `"regr.km"` model and now falls back to a noise variance of `0` as documented.
 * fix: `AcqFunctionEHVI`, `AcqFunctionEHVIGH`, and `AcqFunctionSmsEgo` now apply the surrogate's output transformation to `ys_front`, so the front and the reference point are compared on the same scale.
 * fix: `AcqFunctionEI`, `AcqFunctionEILog`, `AcqFunctionPI`, and `AcqFunctionStochasticEI` now ignore the missing outcomes of pending evaluations when determining the best observed value, so `y_best` is no longer `NA` on an asynchronous archive with more than one worker.

--- a/R/bayesopt_ego.R
+++ b/R/bayesopt_ego.R
@@ -129,7 +129,7 @@ bayesopt_ego = function(
     init_design_size = 4L * search_space$length
   }
   if (!is.null(init_design_size) && instance$archive$n_evals == 0L) {
-    design = generate_design_random(search_space, n = init_design_size)$data
+    design = generate_design_sobol(search_space, n = init_design_size)$data
     instance$eval_batch(design)
   }
 


### PR DESCRIPTION
## Summary

- `bayesopt_ego()` used `generate_design_random()` for the initial design while its roxygen states "Points are generated via a Sobol sequence" and all four sibling loop functions use `generate_design_sobol()`.
- Commit 0521efd3 deliberately made Sobol the default; 57ce8c87 silently regressed only `bayesopt_ego` back to random. This restores `generate_design_sobol()`.

Addresses R35 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)