### PR TITLE
fix: enable random interleaving with user-supplied initial designs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # mlr3mbo (development version)
 
 * fix: `AcqOptimizer` and its subclasses gained `$label` and `$man` fields, so that `as.data.table(mlr_acqoptimizers)` no longer errors.
+* fix: `bayesopt_ego()`, `bayesopt_emo()`, `bayesopt_mpcl()`, `bayesopt_parego()`, and `bayesopt_smsego()` no longer silently disable random interleaving when the archive already contains a user-supplied initial design and `init_design_size` is `NULL`.
 * fix: `AcqFunctionAEI` no longer errors during `$update()` when the surrogate model is not a `"regr.km"` model and now falls back to a noise variance of `0` as documented.
 * fix: `AcqFunctionEHVI`, `AcqFunctionEHVIGH`, and `AcqFunctionSmsEgo` now apply the surrogate's output transformation to `ys_front`, so the front and the reference point are compared on the same scale.
 * fix: `AcqFunctionEI`, `AcqFunctionEILog`, `AcqFunctionPI`, and `AcqFunctionStochasticEI` now ignore the missing outcomes of pending evaluations when determining the best observed value, so `y_best` is no longer `NA` on an asynchronous archive with more than one worker.

--- a/R/bayesopt_ego.R
+++ b/R/bayesopt_ego.R
@@ -132,6 +132,9 @@ bayesopt_ego = function(
     design = generate_design_random(search_space, n = init_design_size)$data
     instance$eval_batch(design)
   }
+  # a user-supplied initial design already in the archive leaves init_design_size NULL,
+  # which would otherwise silently disable random interleaving
+  init_design_size = init_design_size %??% instance$archive$n_evals
 
   # completing initialization
   surrogate$archive = instance$archive

--- a/R/bayesopt_emo.R
+++ b/R/bayesopt_emo.R
@@ -105,6 +105,9 @@ bayesopt_emo = function(
     design = generate_design_sobol(search_space, n = init_design_size)$data
     instance$eval_batch(design)
   }
+  # a user-supplied initial design already in the archive leaves init_design_size NULL,
+  # which would otherwise silently disable random interleaving
+  init_design_size = init_design_size %??% instance$archive$n_evals
 
   # completing initialization
   surrogate$archive = instance$archive

--- a/R/bayesopt_mpcl.R
+++ b/R/bayesopt_mpcl.R
@@ -126,6 +126,9 @@ bayesopt_mpcl = function(
     design = generate_design_sobol(search_space, n = init_design_size)$data
     instance$eval_batch(design)
   }
+  # a user-supplied initial design already in the archive leaves init_design_size NULL,
+  # which would otherwise silently disable random interleaving
+  init_design_size = init_design_size %??% instance$archive$n_evals
 
   # completing initialization
   surrogate$archive = instance$archive

--- a/R/bayesopt_parego.R
+++ b/R/bayesopt_parego.R
@@ -129,6 +129,9 @@ bayesopt_parego = function(
     design = generate_design_sobol(search_space, n = init_design_size)$data
     instance$eval_batch(design)
   }
+  # a user-supplied initial design already in the archive leaves init_design_size NULL,
+  # which would otherwise silently disable random interleaving
+  init_design_size = init_design_size %??% instance$archive$n_evals
 
   # completing initialization
   surrogate$archive = instance$archive

--- a/R/bayesopt_smsego.R
+++ b/R/bayesopt_smsego.R
@@ -113,6 +113,9 @@ bayesopt_smsego = function(
     design = generate_design_sobol(search_space, n = init_design_size)$data
     instance$eval_batch(design)
   }
+  # a user-supplied initial design already in the archive leaves init_design_size NULL,
+  # which would otherwise silently disable random interleaving
+  init_design_size = init_design_size %??% instance$archive$n_evals
 
   # completing initialization
   surrogate$archive = instance$archive

--- a/tests/testthat/test_bayesopt_ego.R
+++ b/tests/testthat/test_bayesopt_ego.R
@@ -209,3 +209,19 @@ test_that("bayesopt_ego random interleave", {
   expect_true(inherits(cond, "Mlr3ErrorMbo"))
   expect_true(inherits(cond, "Mlr3Error"))
 })
+
+test_that("bayesopt_ego random interleave works with a pre-filled archive", {
+  instance = MAKE_INST_1D(terminator = trm("evals", n_evals = 8L))
+  instance$eval_batch(MAKE_DESIGN(instance, n = 4L))
+  surrogate = SurrogateLearner$new(REGR_FEATURELESS)
+  acq_function = AcqFunctionEI$new()
+  acq_optimizer = AcqOptimizer$new(opt("random_search", batch_size = 2L), terminator = trm("evals", n_evals = 2L))
+  bayesopt_ego(
+    instance,
+    surrogate = surrogate,
+    acq_function = acq_function,
+    acq_optimizer = acq_optimizer,
+    random_interleave_iter = 2L
+  )
+  expect_identical(is.na(instance$archive$data$acq_ei), c(rep(TRUE, 4L), FALSE, TRUE, FALSE, TRUE))
+})


### PR DESCRIPTION
## Summary

- With a user-supplied initial design (supported path) and `init_design_size = NULL`, the interleave condition in all five loop functions evaluated `n_evals - NULL + 1L` → `numeric(0)` → `isTRUE(...)` always `FALSE`: random interleaving was silently disabled even though requested.
- `init_design_size` now falls back to `instance$archive$n_evals` after the design block in `bayesopt_ego`, `bayesopt_emo`, `bayesopt_mpcl`, `bayesopt_parego`, and `bayesopt_smsego`.
- Adds a regression test asserting the exact interleave pattern on a pre-filled archive.

Addresses R36 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)