### PR TITLE
fix: subset parego multiplier to target columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # mlr3mbo (development version)
 
 * fix: `AcqOptimizer` and its subclasses gained `$label` and `$man` fields, so that `as.data.table(mlr_acqoptimizers)` no longer errors.
+* fix: `bayesopt_parego()` now subsets the minimization multiplier to the target columns, so the scalarization signs no longer misalign when the codomain holds non-target columns.
 * fix: `AcqFunctionAEI` no longer errors during `$update()` when the surrogate model is not a `"regr.km"` model and now falls back to a noise variance of `0` as documented.
 * fix: `AcqFunctionEHVI`, `AcqFunctionEHVIGH`, and `AcqFunctionSmsEgo` now apply the surrogate's output transformation to `ys_front`, so the front and the reference point are compared on the same scale.
 * fix: `AcqFunctionEI`, `AcqFunctionEILog`, `AcqFunctionPI`, and `AcqFunctionStochasticEI` now ignore the missing outcomes of pending evaluations when determining the best observed value, so `y_best` is no longer `NA` on an asynchronous archive with more than one worker.

--- a/R/bayesopt_parego.R
+++ b/R/bayesopt_parego.R
@@ -144,7 +144,8 @@ bayesopt_parego = function(
   repeat {
     data = instance$archive$data
     ydt = data[, instance$archive$cols_y, with = FALSE]
-    ydt = Map("*", ydt, mult_max_to_min(instance$archive$codomain)) # we always assume minimization
+    # the codomain can hold non-target columns, so the multiplier must be subset to the target columns
+    ydt = Map("*", ydt, mult_max_to_min(instance$archive$codomain)[instance$archive$cols_y]) # we always assume minimization
     ydt = Map(function(y) (y - min(y, na.rm = TRUE)) / diff(range(y, na.rm = TRUE)), ydt) # scale y to [0, 1]
 
     xdt = map_dtr(

--- a/tests/testthat/test_bayesopt_parego.R
+++ b/tests/testthat/test_bayesopt_parego.R
@@ -18,3 +18,26 @@ test_that("default bayesopt_parego", {
   expect_true(!is.na(instance$archive$data$acq_ei[5L]))
   expect_true(is.na(instance$archive$data$y_scal[5L]))
 })
+
+test_that("bayesopt_parego aligns the multiplier with the target columns", {
+  fun = function(xs) list(y1 = as.numeric(xs)^2, time = 1, y2 = -sqrt(abs(as.numeric(xs))))
+  objective = bbotk::ObjectiveRFun$new(
+    fun = fun,
+    domain = PS_1D,
+    codomain = ps(y1 = p_dbl(tags = "minimize"), time = p_dbl(tags = "time"), y2 = p_dbl(tags = "maximize")),
+    properties = "multi-crit"
+  )
+  instance = OptimInstanceBatchMultiCrit$new(objective = objective, terminator = trm("evals", n_evals = 6L))
+  surrogate = SurrogateLearner$new(REGR_FEATURELESS)
+  acq_function = AcqFunctionEI$new()
+  acq_optimizer = AcqOptimizer$new(opt("random_search", batch_size = 2L), terminator = trm("evals", n_evals = 2L))
+
+  expect_no_warning(bayesopt_parego(
+    instance,
+    surrogate = surrogate,
+    acq_function = acq_function,
+    acq_optimizer = acq_optimizer,
+    init_design_size = 4L
+  ))
+  expect_data_table(instance$archive$data, nrows = 6L)
+})


### PR DESCRIPTION
## Summary

- `bayesopt_parego()` multiplied the target-only `ydt` by `mult_max_to_min(instance$archive$codomain)`, a multiplier over the *full* codomain including non-target columns (a case the code explicitly acknowledges a few lines above): signs misaligned positionally and values recycled, silently when the lengths divide.
- The multiplier is now subset by name to `instance$archive$cols_y`.
- Adds a regression test with a non-target `time` column between the two targets; without the fix it fails with a recycling warning and misaligned signs.

Addresses R37 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)