### PR TITLE
fix: handle constant objectives in parego scalarization

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # mlr3mbo (development version)
 
 * fix: `AcqOptimizer` and its subclasses gained `$label` and `$man` fields, so that `as.data.table(mlr_acqoptimizers)` no longer errors.
+* fix: `bayesopt_parego()` now subsets the minimization multiplier to the target columns, so the scalarization signs no longer misalign when the codomain holds non-target columns.
 * fix: `AcqFunctionAEI` no longer errors during `$update()` when the surrogate model is not a `"regr.km"` model and now falls back to a noise variance of `0` as documented.
 * fix: `AcqFunctionEHVI`, `AcqFunctionEHVIGH`, and `AcqFunctionSmsEgo` now apply the surrogate's output transformation to `ys_front`, so the front and the reference point are compared on the same scale.
 * fix: `AcqFunctionEI`, `AcqFunctionEILog`, `AcqFunctionPI`, and `AcqFunctionStochasticEI` now ignore the missing outcomes of pending evaluations when determining the best observed value, so `y_best` is no longer `NA` on an asynchronous archive with more than one worker.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * fix: `AcqOptimizer` and its subclasses gained `$label` and `$man` fields, so that `as.data.table(mlr_acqoptimizers)` no longer errors.
 * fix: `bayesopt_parego()` now subsets the minimization multiplier to the target columns, so the scalarization signs no longer misalign when the codomain holds non-target columns.
+* fix: `bayesopt_parego()` no longer silently degrades to random search when an objective is constant, because the zero-range scaling now maps the constant objective to a constant value instead of `NaN`.
 * fix: `AcqFunctionAEI` no longer errors during `$update()` when the surrogate model is not a `"regr.km"` model and now falls back to a noise variance of `0` as documented.
 * fix: `AcqFunctionEHVI`, `AcqFunctionEHVIGH`, and `AcqFunctionSmsEgo` now apply the surrogate's output transformation to `ys_front`, so the front and the reference point are compared on the same scale.
 * fix: `AcqFunctionEI`, `AcqFunctionEILog`, `AcqFunctionPI`, and `AcqFunctionStochasticEI` now ignore the missing outcomes of pending evaluations when determining the best observed value, so `y_best` is no longer `NA` on an asynchronous archive with more than one worker.

--- a/R/bayesopt_parego.R
+++ b/R/bayesopt_parego.R
@@ -146,7 +146,14 @@ bayesopt_parego = function(
     ydt = data[, instance$archive$cols_y, with = FALSE]
     # the codomain can hold non-target columns, so the multiplier must be subset to the target columns
     ydt = Map("*", ydt, mult_max_to_min(instance$archive$codomain)[instance$archive$cols_y]) # we always assume minimization
-    ydt = Map(function(y) (y - min(y, na.rm = TRUE)) / diff(range(y, na.rm = TRUE)), ydt) # scale y to [0, 1]
+    # scale y to [0, 1]; a constant objective would yield division by zero and is mapped to a constant instead
+    ydt = Map(
+      function(y) {
+        range_y = diff(range(y, na.rm = TRUE))
+        if (range_y == 0) rep(0.5, length(y)) else (y - min(y, na.rm = TRUE)) / range_y
+      },
+      ydt
+    )
 
     xdt = map_dtr(
       qs,

--- a/R/bayesopt_parego.R
+++ b/R/bayesopt_parego.R
@@ -144,7 +144,8 @@ bayesopt_parego = function(
   repeat {
     data = instance$archive$data
     ydt = data[, instance$archive$cols_y, with = FALSE]
-    ydt = Map("*", ydt, mult_max_to_min(instance$archive$codomain)) # we always assume minimization
+    # the codomain can hold non-target columns, so the multiplier must be subset to the target columns
+    ydt = Map("*", ydt, mult_max_to_min(instance$archive$codomain)[instance$archive$cols_y]) # we always assume minimization
     ydt = Map(function(y) (y - min(y, na.rm = TRUE)) / diff(range(y, na.rm = TRUE)), ydt) # scale y to [0, 1]
 
     xdt = map_dtr(

--- a/tests/testthat/test_bayesopt_parego.R
+++ b/tests/testthat/test_bayesopt_parego.R
@@ -18,3 +18,26 @@ test_that("default bayesopt_parego", {
   expect_true(!is.na(instance$archive$data$acq_ei[5L]))
   expect_true(is.na(instance$archive$data$y_scal[5L]))
 })
+
+test_that("bayesopt_parego aligns the multiplier with the target columns", {
+  fun = function(xs) list(y1 = as.numeric(xs)^2, time = 1, y2 = -sqrt(abs(as.numeric(xs))))
+  objective = bbotk::ObjectiveRFun$new(
+    fun = fun,
+    domain = PS_1D,
+    codomain = ps(y1 = p_dbl(tags = "minimize"), time = p_dbl(tags = "time"), y2 = p_dbl(tags = "maximize")),
+    properties = "multi-crit"
+  )
+  instance = OptimInstanceBatchMultiCrit$new(objective = objective, terminator = trm("evals", n_evals = 6L))
+  surrogate = SurrogateLearner$new(REGR_FEATURELESS)
+  acq_function = AcqFunctionEI$new()
+  acq_optimizer = AcqOptimizer$new(opt("random_search", batch_size = 2L), terminator = trm("evals", n_evals = 2L))
+
+  expect_no_warning(bayesopt_parego(
+    instance,
+    surrogate = surrogate,
+    acq_function = acq_function,
+    acq_optimizer = acq_optimizer,
+    init_design_size = 4L
+  ))
+  expect_data_table(instance$archive$data, nrows = 6L)
+})

--- a/tests/testthat/test_bayesopt_parego.R
+++ b/tests/testthat/test_bayesopt_parego.R
@@ -41,3 +41,28 @@ test_that("bayesopt_parego aligns the multiplier with the target columns", {
   ))
   expect_data_table(instance$archive$data, nrows = 6L)
 })
+
+test_that("bayesopt_parego works with a constant objective", {
+  fun = function(xs) list(y1 = as.numeric(xs)^2, y2 = 1)
+  objective = bbotk::ObjectiveRFun$new(
+    fun = fun,
+    domain = PS_1D,
+    codomain = ps(y1 = p_dbl(tags = "minimize"), y2 = p_dbl(tags = "minimize")),
+    properties = "multi-crit"
+  )
+  instance = OptimInstanceBatchMultiCrit$new(objective = objective, terminator = trm("evals", n_evals = 6L))
+  surrogate = SurrogateLearner$new(REGR_FEATURELESS)
+  acq_function = AcqFunctionEI$new()
+  acq_optimizer = AcqOptimizer$new(opt("random_search", batch_size = 2L), terminator = trm("evals", n_evals = 2L))
+
+  bayesopt_parego(
+    instance,
+    surrogate = surrogate,
+    acq_function = acq_function,
+    acq_optimizer = acq_optimizer,
+    init_design_size = 4L
+  )
+
+  expect_true(all(is.finite(head(instance$archive$data$y_scal, 5L))))
+  expect_true(all(!is.na(tail(instance$archive$data$acq_ei, 2L))))
+})


### PR DESCRIPTION
## Summary

- In `bayesopt_parego()`, a constant objective gave `diff(range(y)) == 0`, so the `[0, 1]` scaling produced an all-`NaN` scalarization, every surrogate update failed, and the optimization silently degraded to pure random search behind `catch_errors = TRUE`.
- The zero-range case now maps the constant objective to `0.5`, mirroring the recent `OutputTrafoStandardize` constant-outcome fix.
- Adds a regression test asserting finite scalarizations and model-based proposals with a constant objective.

Stacked on #261 because both change adjacent scalarization lines. Addresses R38 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)