### PR TITLE
fix: log caught errors in bayesopt_mpcl

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # mlr3mbo (development version)
 
 * fix: `AcqOptimizer` and its subclasses gained `$label` and `$man` fields, so that `as.data.table(mlr_acqoptimizers)` no longer errors.
+* fix: `bayesopt_mpcl()` now logs a warning when a surrogate or acquisition function error is caught and a randomly sampled point is proposed, consistent with the other loop functions.
 * fix: `AcqFunctionAEI` no longer errors during `$update()` when the surrogate model is not a `"regr.km"` model and now falls back to a noise variance of `0` as documented.
 * fix: `AcqFunctionEHVI`, `AcqFunctionEHVIGH`, and `AcqFunctionSmsEgo` now apply the surrogate's output transformation to `ys_front`, so the front and the reference point are compared on the same scale.
 * fix: `AcqFunctionEI`, `AcqFunctionEILog`, `AcqFunctionPI`, and `AcqFunctionStochasticEI` now ignore the missing outcomes of pending evaluations when determining the best observed value, so `y_best` is no longer `NA` on an asynchronous archive with more than one worker.

--- a/R/bayesopt_mpcl.R
+++ b/R/bayesopt_mpcl.R
@@ -144,7 +144,8 @@ bayesopt_mpcl = function(
         acq_optimizer$optimize()
       },
       Mlr3ErrorMbo = function(cond) {
-        #lg$info("Proposing a randomly sampled point") no logging because we do not evaluate this point
+        lg$warn("Caught the following error: %s", cond$message)
+        lg$info("Proposing a randomly sampled point")
         generate_design_random(search_space, n = 1L)$data
       }
     )


### PR DESCRIPTION
## Summary

- The `Mlr3ErrorMbo` handler of `bayesopt_mpcl()`'s first proposal swallowed surrogate/acquisition failures with no log at all, while the other four loop functions log a warning. The comment justifying the silence ("we do not evaluate this point") was factually wrong — the fallback point is rbound to the batch and evaluated.
- The handler now logs the caught error at warn level and the random fallback at info level, consistent with the siblings, and the commented-out line is removed.

Addresses R39 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)