### PR TITLE
fix: advance random interleave counter per proposal in mpcl and parego

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * fix: `AcqOptimizer` and its subclasses gained `$label` and `$man` fields, so that `as.data.table(mlr_acqoptimizers)` no longer errors.
 * fix: `bayesopt_mpcl()` now logs a warning when a surrogate or acquisition function error is caught and a randomly sampled point is proposed, consistent with the other loop functions.
+* fix: `bayesopt_mpcl()` no longer aborts when a batch mixes model-based proposals and randomly sampled fallback points, because the batch is now combined with filling missing columns.
+* fix: `bayesopt_mpcl()` and `bayesopt_parego()` now advance the random interleaving counter per proposal instead of per batch, so random interleaving also triggers for `q > 1` as documented.
 * fix: `bayesopt_parego()` now subsets the minimization multiplier to the target columns, so the scalarization signs no longer misalign when the codomain holds non-target columns.
 * fix: `bayesopt_parego()` no longer silently degrades to random search when an objective is constant, because the zero-range scaling now maps the constant objective to a constant value instead of `NaN`.
 * fix: `AcqFunctionAEI` no longer errors during `$update()` when the surrogate model is not a `"regr.km"` model and now falls back to a noise variance of `0` as documented.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # mlr3mbo (development version)
 
 * fix: `AcqOptimizer` and its subclasses gained `$label` and `$man` fields, so that `as.data.table(mlr_acqoptimizers)` no longer errors.
+* fix: `bayesopt_parego()` now subsets the minimization multiplier to the target columns, so the scalarization signs no longer misalign when the codomain holds non-target columns.
 * fix: `AcqFunctionAEI` no longer errors during `$update()` when the surrogate model is not a `"regr.km"` model and now falls back to a noise variance of `0` as documented.
 * fix: `AcqFunctionEHVI`, `AcqFunctionEHVIGH`, and `AcqFunctionSmsEgo` now apply the surrogate's output transformation to `ys_front`, so the front and the reference point are compared on the same scale.
 * fix: `AcqFunctionEI`, `AcqFunctionEILog`, `AcqFunctionPI`, and `AcqFunctionStochasticEI` now ignore the missing outcomes of pending evaluations when determining the best observed value, so `y_best` is no longer `NA` on an asynchronous archive with more than one worker.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # mlr3mbo (development version)
 
 * fix: `AcqOptimizer` and its subclasses gained `$label` and `$man` fields, so that `as.data.table(mlr_acqoptimizers)` no longer errors.
+* fix: `bayesopt_mpcl()` now logs a warning when a surrogate or acquisition function error is caught and a randomly sampled point is proposed, consistent with the other loop functions.
 * fix: `AcqFunctionAEI` no longer errors during `$update()` when the surrogate model is not a `"regr.km"` model and now falls back to a noise variance of `0` as documented.
 * fix: `AcqFunctionEHVI`, `AcqFunctionEHVIGH`, and `AcqFunctionSmsEgo` now apply the surrogate's output transformation to `ys_front`, so the front and the reference point are compared on the same scale.
 * fix: `AcqFunctionEI`, `AcqFunctionEILog`, `AcqFunctionPI`, and `AcqFunctionStochasticEI` now ignore the missing outcomes of pending evaluations when determining the best observed value, so `y_best` is no longer `NA` on an asynchronous archive with more than one worker.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * fix: `AcqOptimizer` and its subclasses gained `$label` and `$man` fields, so that `as.data.table(mlr_acqoptimizers)` no longer errors.
 * fix: `bayesopt_parego()` now subsets the minimization multiplier to the target columns, so the scalarization signs no longer misalign when the codomain holds non-target columns.
+* fix: `bayesopt_parego()` no longer silently degrades to random search when an objective is constant, because the zero-range scaling now maps the constant objective to a constant value instead of `NaN`.
 * fix: `AcqFunctionAEI` no longer errors during `$update()` when the surrogate model is not a `"regr.km"` model and now falls back to a noise variance of `0` as documented.
 * fix: `AcqFunctionEHVI`, `AcqFunctionEHVIGH`, and `AcqFunctionSmsEgo` now apply the surrogate's output transformation to `ys_front`, so the front and the reference point are compared on the same scale.
 * fix: `AcqFunctionEI`, `AcqFunctionEILog`, `AcqFunctionPI`, and `AcqFunctionStochasticEI` now ignore the missing outcomes of pending evaluations when determining the best observed value, so `y_best` is no longer `NA` on an asynchronous archive with more than one worker.

--- a/R/bayesopt_mpcl.R
+++ b/R/bayesopt_mpcl.R
@@ -144,7 +144,8 @@ bayesopt_mpcl = function(
         acq_optimizer$optimize()
       },
       Mlr3ErrorMbo = function(cond) {
-        #lg$info("Proposing a randomly sampled point") no logging because we do not evaluate this point
+        lg$warn("Caught the following error: %s", cond$message)
+        lg$info("Proposing a randomly sampled point")
         generate_design_random(search_space, n = 1L)$data
       }
     )

--- a/R/bayesopt_mpcl.R
+++ b/R/bayesopt_mpcl.R
@@ -139,9 +139,18 @@ bayesopt_mpcl = function(
     # normal ego proposal with error catching
     xdt = tryCatch(
       {
+        # random interleaving is handled here; the counter must advance per proposal, not per batch
+        if (isTRUE((instance$archive$n_evals - init_design_size + 1L) %% random_interleave_iter == 0)) {
+          error_random_interleave("Random interleaving")
+        }
+
         acq_function$surrogate$update()
         acq_function$update()
         acq_optimizer$optimize()
+      },
+      Mlr3ErrorMboRandomInterleave = function(cond) {
+        lg$info("Random interleaving triggered, proposing a randomly sampled point")
+        generate_design_random(search_space, n = 1L)$data
       },
       Mlr3ErrorMbo = function(cond) {
         lg$warn("Caught the following error: %s", cond$message)
@@ -169,8 +178,8 @@ bayesopt_mpcl = function(
             ydt = lie
           )
 
-          # random interleaving is handled here
-          if (isTRUE((instance$archive$n_evals - init_design_size + 1L) %% random_interleave_iter == 0)) {
+          # random interleaving is handled here; the counter must advance per proposal, not per batch
+          if (isTRUE((instance$archive$n_evals - init_design_size + i) %% random_interleave_iter == 0)) {
             error_random_interleave("Random interleaving")
           }
 
@@ -189,7 +198,8 @@ bayesopt_mpcl = function(
           generate_design_random(search_space, n = 1L)$data
         }
       )
-      xdt = rbind(xdt, xdt_new)
+      # fill because randomly sampled fallback points lack the acquisition function columns
+      xdt = rbind(xdt, xdt_new, fill = TRUE)
     }
 
     acq_function$surrogate$archive = instance$archive

--- a/R/bayesopt_parego.R
+++ b/R/bayesopt_parego.R
@@ -146,7 +146,14 @@ bayesopt_parego = function(
     ydt = data[, instance$archive$cols_y, with = FALSE]
     # the codomain can hold non-target columns, so the multiplier must be subset to the target columns
     ydt = Map("*", ydt, mult_max_to_min(instance$archive$codomain)[instance$archive$cols_y]) # we always assume minimization
-    ydt = Map(function(y) (y - min(y, na.rm = TRUE)) / diff(range(y, na.rm = TRUE)), ydt) # scale y to [0, 1]
+    # scale y to [0, 1]; a constant objective would yield division by zero and is mapped to a constant instead
+    ydt = Map(
+      function(y) {
+        range_y = diff(range(y, na.rm = TRUE))
+        if (range_y == 0) rep(0.5, length(y)) else (y - min(y, na.rm = TRUE)) / range_y
+      },
+      ydt
+    )
 
     xdt = map_dtr(
       qs,

--- a/R/bayesopt_parego.R
+++ b/R/bayesopt_parego.R
@@ -144,7 +144,8 @@ bayesopt_parego = function(
   repeat {
     data = instance$archive$data
     ydt = data[, instance$archive$cols_y, with = FALSE]
-    ydt = Map("*", ydt, mult_max_to_min(instance$archive$codomain)) # we always assume minimization
+    # the codomain can hold non-target columns, so the multiplier must be subset to the target columns
+    ydt = Map("*", ydt, mult_max_to_min(instance$archive$codomain)[instance$archive$cols_y]) # we always assume minimization
     ydt = Map(function(y) (y - min(y, na.rm = TRUE)) / diff(range(y, na.rm = TRUE)), ydt) # scale y to [0, 1]
 
     xdt = map_dtr(

--- a/R/bayesopt_parego.R
+++ b/R/bayesopt_parego.R
@@ -157,7 +157,7 @@ bayesopt_parego = function(
 
     xdt = map_dtr(
       qs,
-      function(q) {
+      function(i) {
         # scalarize y
         lambda = lambdas[sample.int(nrow(lambdas), 1L), , drop = TRUE]
         mult = Map("*", ydt, lambda)
@@ -167,8 +167,8 @@ bayesopt_parego = function(
 
         tryCatch(
           {
-            # random interleaving is handled here
-            if (isTRUE((instance$archive$n_evals - init_design_size + 1L) %% random_interleave_iter == 0)) {
+            # random interleaving is handled here; the counter must advance per proposal, not per batch
+            if (isTRUE((instance$archive$n_evals - init_design_size + i) %% random_interleave_iter == 0)) {
               error_random_interleave("Random interleaving")
             }
             acq_function$surrogate$update()

--- a/tests/testthat/test_bayesopt_mpcl.R
+++ b/tests/testthat/test_bayesopt_mpcl.R
@@ -17,3 +17,22 @@ test_that("default bayesopt_mpcl", {
   expect_true(!is.na(instance$archive$data$acq_ei[6L]))
   expect_true(all(instance$archive$data$batch_nr[c(5L, 6L)] == c(2L, 2L)))
 })
+
+test_that("bayesopt_mpcl random interleave triggers per proposal", {
+  instance = MAKE_INST_1D(terminator = trm("evals", n_evals = 8L))
+  surrogate = SurrogateLearner$new(REGR_FEATURELESS)
+  acq_function = AcqFunctionEI$new()
+  acq_optimizer = AcqOptimizer$new(opt("random_search", batch_size = 2L), terminator = trm("evals", n_evals = 2L))
+
+  bayesopt_mpcl(
+    instance,
+    surrogate = surrogate,
+    acq_function = acq_function,
+    acq_optimizer = acq_optimizer,
+    init_design_size = 4L,
+    q = 2L,
+    random_interleave_iter = 2L
+  )
+
+  expect_identical(is.na(instance$archive$data$acq_ei), c(rep(TRUE, 4L), FALSE, TRUE, FALSE, TRUE))
+})

--- a/tests/testthat/test_bayesopt_parego.R
+++ b/tests/testthat/test_bayesopt_parego.R
@@ -18,3 +18,26 @@ test_that("default bayesopt_parego", {
   expect_true(!is.na(instance$archive$data$acq_ei[5L]))
   expect_true(is.na(instance$archive$data$y_scal[5L]))
 })
+
+test_that("bayesopt_parego aligns the multiplier with the target columns", {
+  fun = function(xs) list(y1 = as.numeric(xs)^2, time = 1, y2 = -sqrt(abs(as.numeric(xs))))
+  objective = bbotk::ObjectiveRFun$new(
+    fun = fun,
+    domain = PS_1D,
+    codomain = ps(y1 = p_dbl(tags = "minimize"), time = p_dbl(tags = "time"), y2 = p_dbl(tags = "maximize")),
+    properties = "multi-crit"
+  )
+  instance = OptimInstanceBatchMultiCrit$new(objective = objective, terminator = trm("evals", n_evals = 6L))
+  surrogate = SurrogateLearner$new(REGR_FEATURELESS)
+  acq_function = AcqFunctionEI$new()
+  acq_optimizer = AcqOptimizer$new(opt("random_search", batch_size = 2L), terminator = trm("evals", n_evals = 2L))
+
+  expect_no_warning(bayesopt_parego(
+    instance,
+    surrogate = surrogate,
+    acq_function = acq_function,
+    acq_optimizer = acq_optimizer,
+    init_design_size = 4L
+  ))
+  expect_data_table(instance$archive$data, nrows = 6L)
+})

--- a/tests/testthat/test_bayesopt_parego.R
+++ b/tests/testthat/test_bayesopt_parego.R
@@ -66,3 +66,22 @@ test_that("bayesopt_parego works with a constant objective", {
   expect_true(all(is.finite(head(instance$archive$data$y_scal, 5L))))
   expect_true(all(!is.na(tail(instance$archive$data$acq_ei, 2L))))
 })
+
+test_that("bayesopt_parego random interleave triggers per proposal", {
+  instance = MAKE_INST(OBJ_1D_2, search_space = PS_1D, terminator = trm("evals", n_evals = 8L))
+  surrogate = SurrogateLearner$new(REGR_FEATURELESS)
+  acq_function = AcqFunctionEI$new()
+  acq_optimizer = AcqOptimizer$new(opt("random_search", batch_size = 2L), terminator = trm("evals", n_evals = 2L))
+
+  bayesopt_parego(
+    instance,
+    surrogate = surrogate,
+    acq_function = acq_function,
+    acq_optimizer = acq_optimizer,
+    init_design_size = 4L,
+    q = 2L,
+    random_interleave_iter = 2L
+  )
+
+  expect_identical(is.na(instance$archive$data$acq_ei), c(rep(TRUE, 4L), FALSE, TRUE, FALSE, TRUE))
+})

--- a/tests/testthat/test_bayesopt_parego.R
+++ b/tests/testthat/test_bayesopt_parego.R
@@ -41,3 +41,28 @@ test_that("bayesopt_parego aligns the multiplier with the target columns", {
   ))
   expect_data_table(instance$archive$data, nrows = 6L)
 })
+
+test_that("bayesopt_parego works with a constant objective", {
+  fun = function(xs) list(y1 = as.numeric(xs)^2, y2 = 1)
+  objective = bbotk::ObjectiveRFun$new(
+    fun = fun,
+    domain = PS_1D,
+    codomain = ps(y1 = p_dbl(tags = "minimize"), y2 = p_dbl(tags = "minimize")),
+    properties = "multi-crit"
+  )
+  instance = OptimInstanceBatchMultiCrit$new(objective = objective, terminator = trm("evals", n_evals = 6L))
+  surrogate = SurrogateLearner$new(REGR_FEATURELESS)
+  acq_function = AcqFunctionEI$new()
+  acq_optimizer = AcqOptimizer$new(opt("random_search", batch_size = 2L), terminator = trm("evals", n_evals = 2L))
+
+  bayesopt_parego(
+    instance,
+    surrogate = surrogate,
+    acq_function = acq_function,
+    acq_optimizer = acq_optimizer,
+    init_design_size = 4L
+  )
+
+  expect_true(all(is.finite(head(instance$archive$data$y_scal, 5L))))
+  expect_true(all(!is.na(tail(instance$archive$data$acq_ei, 2L))))
+})


### PR DESCRIPTION
## Summary

- For `q > 1`, `n_evals` is constant within a batch, so the interleave counter in `bayesopt_mpcl()` and `bayesopt_parego()` advanced by `q` per batch; with `q = 2, random_interleave_iter = 2` interleaving never triggered, for any run length. The proposal slot index now enters the interleave condition, making the counter per-proposal as documented.
- `bayesopt_parego()`'s inner loop variable is renamed from `q` (which shadowed the batch size argument, the naming trap behind this bug) to `i`.
- `bayesopt_mpcl()` additionally gets the interleave check on the first proposal of each batch, and the batch `rbind()` now uses `fill = TRUE`, because randomly sampled fallback points lack the acquisition function columns and previously aborted the whole optimization (Blocking #8 of the review; `bayesopt_parego` already does the equivalent via `map_dtr(..., .fill = TRUE)`).
- Adds regression tests asserting the exact per-proposal interleave pattern for both loop functions with `q = 2`.

Stacked on #262 and includes #263's commit (same conflict regions). Addresses R40 and Blocking #8 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)