### PR TITLE
fix: reject additional arguments in mlr_loop_functions$get()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * fix: `AcqOptimizerLbfgsb` now raises a catchable acquisition function optimizer error instead of an unrelated error when no restart produces a valid solution, so the loop function can fall back to a randomly sampled point.
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.
 * fix: `OptimizerADBO` and `TunerADBO` now draw the initial lambda from an exponential distribution as documented, so that the `lambda` parameter has an effect.
+* fix: `mlr_loop_functions$get()` now raises an error when additional arguments are passed, because loop functions are stored as plain values and the arguments were silently discarded before.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
 * fix: `ResultAssignerSurrogate` no longer errors when the archive contains duplicated x-configurations.
 * fix: `srlrn()` now correctly unwraps a single learner supplied in a list instead of erroring.

--- a/R/mlr_loop_functions.R
+++ b/R/mlr_loop_functions.R
@@ -23,22 +23,24 @@ mlr_loop_functions = R6Class(
   public = list(
     #' @description
     #' Retrieves object with key `key` from the dictionary.
-    #' Additional arguments must be named and are passed to the constructor of the stored object.
     #'
     #' @param key (`character(1)`).
     #'
     #' @param ... (`any`)\cr
-    #' Passed down to constructor.
+    #' Must be empty, because loop functions are stored as plain values and nothing is constructed.
     #'
     #' @return Object with corresponding key.
     get = function(key, ...) {
       assert_string(key, min.chars = 1L)
-      dictionary_loop_function_get(self, key, ...)
+      if (...length() > 0L) {
+        stopf("Loop functions are stored as plain values, so additional arguments must not be passed to $get().")
+      }
+      dictionary_loop_function_get(self, key)
     }
   )
 )$new()
 
-dictionary_loop_function_get = function(self, key, ...) {
+dictionary_loop_function_get = function(self, key) {
   obj = dictionary_loop_function_retrieve_item(self, key)
   obj$value
 }

--- a/man/mlr_loop_functions.Rd
+++ b/man/mlr_loop_functions.Rd
@@ -10,7 +10,7 @@
 \item{key}{(\code{character(1)}).}
 
 \item{...}{(\code{any})\cr
-Passed down to constructor.}
+Must be empty, because loop functions are stored as plain values and nothing is constructed.}
 }
 \value{
 Object with corresponding key.
@@ -20,7 +20,6 @@ A simple \link[mlr3misc:Dictionary]{mlr3misc::Dictionary} storing objects of cla
 Each loop function has an associated help page, see \code{mlr_loop_functions_[id]}.
 
 Retrieves object with key \code{key} from the dictionary.
-Additional arguments must be named and are passed to the constructor of the stored object.
 }
 \section{Methods}{
 

--- a/tests/testthat/test_mlr_loop_functions.R
+++ b/tests/testthat/test_mlr_loop_functions.R
@@ -75,3 +75,7 @@ test_that("custom loop_function", {
 
   optimizer$optimize(instance)
 })
+
+test_that("mlr_loop_functions get rejects additional arguments", {
+  expect_error(mlr_loop_functions$get("bayesopt_ego", init_design_size = 10L), "must not be passed")
+})


### PR DESCRIPTION
## Summary

- `mlr_loop_functions$get(key, ...)` accepted and silently discarded `...` while the docs claimed they are "passed to the constructor of the stored object"; loop functions are plain values and nothing is constructed, so `mlr_loop_functions$get("bayesopt_ego", init_design_size = 10)` silently ignored the argument.
- The method now errors on non-empty dots with an explanatory message, and the docs are corrected.

Addresses R41 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)