### PR TITLE
fix: implement documented single-learner replication in srlrn()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
 * fix: `ResultAssignerSurrogate` no longer errors when the archive contains duplicated x-configurations.
 * fix: `srlrn()` now correctly unwraps a single learner supplied in a list instead of erroring.
+* fix: `srlrn()` now implements the documented replication of a single learner when `cols_y` or the `archive` reference more than one target variable, returning a `SurrogateLearnerCollection` with deep clones of the learner.
 * fix: `SurrogateLearner$predict()` no longer modifies the data.table passed as `xdt` by reference.
 
 # mlr3mbo 1.1.1

--- a/R/sugar.R
+++ b/R/sugar.R
@@ -44,38 +44,38 @@ srlrn = function(learner, input_trafo = NULL, output_trafo = NULL, archive = NUL
   dots = list(...)
   assert_learner_surrogate(learner)
 
-  surrogate = if (test_r6(learner, classes = "Learner")) {
+  learners = if (test_r6(learner, classes = "Learner")) list(learner) else learner
+  n_targets = if (!is.null(cols_y)) {
+    length(cols_y)
+  } else if (!is.null(archive)) {
+    length(archive$cols_y)
+  } else {
+    length(learners)
+  }
+  if (length(learners) == 1L && n_targets > 1L) {
+    # replicate a single learner as many times as needed via deep clones
+    learners = map(seq_len(n_targets), function(i) learners[[1L]]$clone(deep = TRUE))
+  }
+
+  surrogate = if (length(learners) == 1L) {
     SurrogateLearner$new(
-      learner = learner,
+      learner = learners[[1L]],
       input_trafo = input_trafo,
       output_trafo = output_trafo,
       archive = archive,
       cols_x = cols_x,
       col_y = cols_y
     )
-  } else if (inherits(learner, what = "list")) {
-    if (length(learner) == 1L) {
-      learner = learner[[1L]]
-      # if a single learner is provided in a list, we unlist it
-      SurrogateLearner$new(
-        learner = learner,
-        input_trafo = input_trafo,
-        output_trafo = output_trafo,
-        archive = archive,
-        cols_x = cols_x,
-        col_y = cols_y
-      )
-    } else {
-      assert_character(cols_y, len = length(learner), null.ok = TRUE)
-      SurrogateLearnerCollection$new(
-        learners = learner,
-        input_trafo = input_trafo,
-        output_trafo = output_trafo,
-        archive = archive,
-        cols_x = cols_x,
-        cols_y = cols_y
-      )
-    }
+  } else {
+    assert_character(cols_y, len = length(learners), null.ok = TRUE)
+    SurrogateLearnerCollection$new(
+      learners = learners,
+      input_trafo = input_trafo,
+      output_trafo = output_trafo,
+      archive = archive,
+      cols_x = cols_x,
+      cols_y = cols_y
+    )
   }
   surrogate$param_set$values = insert_named(surrogate$param_set$values, dots)
   surrogate

--- a/tests/testthat/test_sugar.R
+++ b/tests/testthat/test_sugar.R
@@ -43,3 +43,15 @@ test_that("OutputTrafo sugar", {
   outputtrafo = ot("log")
   expect_r6(outputtrafo, "OutputTrafo")
 })
+
+test_that("srlrn replicates a single learner for multiple targets", {
+  surrogate = srlrn(lrn("regr.featureless"), cols_y = c("y1", "y2"))
+  expect_r6(surrogate, "SurrogateLearnerCollection")
+  expect_length(surrogate$learner, 2L)
+  expect_false(address(surrogate$learner[[1L]]) == address(surrogate$learner[[2L]]))
+
+  inst = MAKE_INST(OBJ_1D_2, search_space = PS_1D, terminator = trm("evals", n_evals = 5L))
+  surrogate = srlrn(lrn("regr.featureless"), archive = inst$archive)
+  expect_r6(surrogate, "SurrogateLearnerCollection")
+  expect_length(surrogate$learner, 2L)
+})


### PR DESCRIPTION
## Summary

- `srlrn()` documented that a single learner is replicated as many times as needed when the `archive` or `cols_y` reference more than one target variable, but this did not exist: `srlrn(lrn(...), cols_y = c("y1", "y2"))` errored and a multi-crit `archive` silently returned a single-target `SurrogateLearner`.
- The replication is now implemented: the number of targets is inferred from `cols_y` (or the archive), and a single learner is deep cloned per target to build a `SurrogateLearnerCollection` (the collection requires learners that are unique in memory).
- Adds tests for both the `cols_y` and the archive inference path.

Addresses R42 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)