### PR TITLE
fix: reject terminator and callbacks for dictionary keys in acqo()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # mlr3mbo (development version)
 
+* fix: `acqo()` now raises an error when `terminator` or `callbacks` are combined with a dictionary key as `optimizer`, because these arguments were silently discarded before.
 * fix: `AcqOptimizer` and its subclasses gained `$label` and `$man` fields, so that `as.data.table(mlr_acqoptimizers)` no longer errors.
 * fix: `AcqFunctionAEI` no longer errors during `$update()` when the surrogate model is not a `"regr.km"` model and now falls back to a noise variance of `0` as documented.
 * fix: `AcqFunctionEHVI`, `AcqFunctionEHVIGH`, and `AcqFunctionSmsEgo` now apply the surrogate's output transformation to `ys_front`, so the front and the reference point are compared on the same scale.

--- a/R/sugar.R
+++ b/R/sugar.R
@@ -160,6 +160,11 @@ acqo = function(optimizer, terminator, acq_function = NULL, callbacks = NULL, ..
   dots = list(...)
 
   if (is.character(optimizer)) {
+    if (!missing(terminator) || !is.null(callbacks)) {
+      stopf(
+        "'terminator' and 'callbacks' must not be given when 'optimizer' is a key of mlr_acqoptimizers, because the pre-defined acquisition function optimizers do not use them."  # nolint
+      )
+    }
     return(dictionary_sugar_get(mlr_acqoptimizers, optimizer, acq_function = acq_function, ...))
   }
 

--- a/tests/testthat/test_conditions.R
+++ b/tests/testthat/test_conditions.R
@@ -48,7 +48,7 @@ test_that("conditions work", {
 
   surrogate = SurrogateLearner$new(learner)
   acq_function = AcqFunctionEI$new()
-  acq_optimizer = acqo("random_search", terminator = trm("evals", n_evals = 2L))
+  acq_optimizer = acqo("random_search")
   expect_snapshot(bayesopt_ego(
     instance,
     surrogate = surrogate,
@@ -72,7 +72,7 @@ test_that("conditions work", {
 
   surrogate = SurrogateLearner$new(learner)
   acq_function = AcqFunctionEI$new()
-  acq_optimizer = acqo("random_search", terminator = trm("evals", n_evals = 2L))
+  acq_optimizer = acqo("random_search")
   expect_snapshot(bayesopt_ego(
     instance,
     surrogate = surrogate,

--- a/tests/testthat/test_sugar.R
+++ b/tests/testthat/test_sugar.R
@@ -43,3 +43,8 @@ test_that("OutputTrafo sugar", {
   outputtrafo = ot("log")
   expect_r6(outputtrafo, "OutputTrafo")
 })
+
+test_that("acqo errors when terminator or callbacks are combined with a dictionary key", {
+  expect_error(acqo("random_search", terminator = trm("evals")), "must not be given")
+  expect_error(acqo("random_search", callbacks = list()), "must not be given")
+})


### PR DESCRIPTION
## Summary

- `acqo("local_search", trm("evals"), callbacks = ...)` silently discarded both `terminator` and `callbacks` when `optimizer` was given as a dictionary key.
- `acqo()` now raises an informative error when either argument is combined with a character key, because the pre-defined acquisition function optimizers do not use them.

Addresses R43 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)