### PR TITLE
docs: state that default_rf() ignores the noisy argument

### DIFF
--- a/R/mbo_defaults.R
+++ b/R/mbo_defaults.R
@@ -102,6 +102,8 @@ default_gp = function(noisy = FALSE) {
 #' @param noisy (`logical(1)`)\cr
 #'   Whether the learner will be used in a noisy objective function scenario.
 #'   See [default_surrogate()].
+#'   Currently, the constructed random forest is identical in the noisy and deterministic case,
+#'   and the argument only exists for consistency with [default_gp()].
 #' @return [mlr3learners::LearnerRegrRanger]
 #' @family mbo_defaults
 #' @export

--- a/man/default_rf.Rd
+++ b/man/default_rf.Rd
@@ -9,7 +9,9 @@ default_rf(noisy = FALSE)
 \arguments{
 \item{noisy}{(\code{logical(1)})\cr
 Whether the learner will be used in a noisy objective function scenario.
-See \code{\link[=default_surrogate]{default_surrogate()}}.}
+See \code{\link[=default_surrogate]{default_surrogate()}}.
+Currently, the constructed random forest is identical in the noisy and deterministic case,
+and the argument only exists for consistency with \code{\link[=default_gp]{default_gp()}}.}
 }
 \value{
 \link[mlr3learners:LearnerRegrRanger]{mlr3learners::LearnerRegrRanger}


### PR DESCRIPTION
## Summary

- `default_rf(noisy)` asserts and documents its `noisy` argument but never uses it; `default_rf(TRUE)` and `default_rf(FALSE)` are identical.
- The random forest defaults are empirically derived from the benchmark study and no noisy-specific configuration exists, so instead of inventing one, the docs now state that the argument currently has no effect and only exists for consistency with `default_gp()`.

Addresses R44 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)