### PR TITLE
docs: clarify that only default surrogate learners are encapsulated

### DIFF
--- a/R/mbo_defaults.R
+++ b/R/mbo_defaults.R
@@ -134,8 +134,9 @@ default_rf = function(noisy = FALSE) {
 #' For mixed numeric-categorical parameter spaces, or spaces with conditional parameters
 #' a random forest is constructed via [default_rf()].
 #'
-#' In any case, learners are encapsulated using `"evaluate"`, and a fallback learner is set,
+#' These default learners are encapsulated using `"evaluate"`, and a fallback learner is set,
 #' in cases where the surrogate learner errors.
+#' A user-supplied `learner` is used as is, without encapsulation or a fallback learner.
 #' Currently, the following learner is used as a fallback:
 #' `lrn("regr.ranger", num.trees = 10L, keep.inbag = TRUE, se.method = "jack")`.
 #'

--- a/man/default_surrogate.Rd
+++ b/man/default_surrogate.Rd
@@ -37,8 +37,9 @@ a Gaussian Process is constricted via \code{\link[=default_gp]{default_gp()}}.
 For mixed numeric-categorical parameter spaces, or spaces with conditional parameters
 a random forest is constructed via \code{\link[=default_rf]{default_rf()}}.
 
-In any case, learners are encapsulated using \code{"evaluate"}, and a fallback learner is set,
+These default learners are encapsulated using \code{"evaluate"}, and a fallback learner is set,
 in cases where the surrogate learner errors.
+A user-supplied \code{learner} is used as is, without encapsulation or a fallback learner.
 Currently, the following learner is used as a fallback:
 \code{lrn("regr.ranger", num.trees = 10L, keep.inbag = TRUE, se.method = "jack")}.
 


### PR DESCRIPTION
## Summary

- The `default_surrogate()` docs claimed "In any case, learners are encapsulated ... and a fallback learner is set", but encapsulation only happens in the `is.null(learner)` branch; a user-supplied `learner` is used as is.
- The docs now state this explicitly.

Addresses R45 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)