### PR TITLE
fix: error on unsupported instance classes in default_acqfunction()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * fix: `AcqOptimizerDirect` and `AcqOptimizerLbfgsb` now reset their `state` at the start of each `optimize()` call and clear it on `reset()`, so the `state` no longer grows unboundedly across a Bayesian optimization loop.
 * fix: `AcqOptimizerLbfgsb` now raises a catchable acquisition function optimizer error instead of an unrelated error when no restart produces a valid solution, so the loop function can fall back to a randomly sampled point.
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.
+* fix: `default_acqfunction()` now raises an informative error for unsupported instance classes instead of returning invisible `NULL`.
 * fix: `OptimizerADBO` and `TunerADBO` now draw the initial lambda from an exponential distribution as documented, so that the `lambda` parameter has an effect.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
 * fix: `ResultAssignerSurrogate` no longer errors when the archive contains duplicated x-configurations.

--- a/R/mbo_defaults.R
+++ b/R/mbo_defaults.R
@@ -216,7 +216,7 @@ default_acqfunction = function(instance) {
     AcqFunctionStochasticCB$new()
   } else if (inherits(instance, "OptimInstanceBatchMultiCrit")) {
     AcqFunctionSmsEgo$new()
-  } else if (inherits(instance, "OptimInstanceAsyncMultiCrit")) {
+  } else {
     stopf("Currently, there is no default acquisition function for %s.", class(instance)[1L])
   }
 }

--- a/tests/testthat/test_mbo_defaults.R
+++ b/tests/testthat/test_mbo_defaults.R
@@ -268,3 +268,9 @@ test_that("stability and defaults", {
   # Nothing should happen here due to the fallback learner
   expect_true(sum(grepl("Surrogate Train Error", unlist(map(strsplit(lines, "\\[bbotk\\] "), 2L)))) == 0L)
 })
+
+test_that("default_acqfunction errors for unsupported instance classes", {
+  instance = MAKE_INST_1D()
+  class(instance) = c("OptimInstanceCustom", "OptimInstance", "R6")
+  expect_error(default_acqfunction(instance), "no default acquisition function")
+})


### PR DESCRIPTION
## Summary

- `default_acqfunction()`'s dispatch chain ended with an `else if`, so an unmatched instance class returned invisible `NULL`, propagating a confusing failure into `OptimizerMbo`.
- The chain now ends with a terminal `else stopf(...)`, which also covers the previously special-cased `OptimInstanceAsyncMultiCrit` with the identical message.
- Adds a test with an unsupported instance class.

Addresses R46 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)