### PR TITLE
test: build OBJ_1D_2_NOISY from the noisy objective function

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -51,7 +51,7 @@ FUN_1D_2_NOISY = function(xs) {
   list(y1 = as.numeric(xs)^2 + rnorm(1, sd = 0.5), y2 = sqrt(abs(as.numeric(xs))) + rnorm(1, sd = 0.5))
 }
 OBJ_1D_2_NOISY = bbotk::ObjectiveRFun$new(
-  fun = FUN_1D_2,
+  fun = FUN_1D_2_NOISY,
   domain = PS_1D,
   codomain = FUN_1D_2_CODOMAIN,
   properties = c("multi-crit", "noisy")


### PR DESCRIPTION
## Summary

- The "noisy" multi-crit test fixture `OBJ_1D_2_NOISY` was built from the deterministic `FUN_1D_2` instead of `FUN_1D_2_NOISY` (defined directly above it and previously dead), so it added no noise while claiming the `noisy` property.
- The fixture now uses the noisy function; its only consumer (`test_mbo_defaults.R`) still passes.

Addresses R47 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)