### PR TITLE
test: exercise the catch_errors = FALSE path of Surrogate$update()

### DIFF
--- a/tests/testthat/test_SurrogateLearner.R
+++ b/tests/testthat/test_SurrogateLearner.R
@@ -21,7 +21,7 @@ test_that("SurrogateLearner API works", {
   expect_error(surrogate$update(), class = "Mlr3ErrorMboSurrogateUpdate")
 
   surrogate$param_set$values$catch_errors = FALSE
-  expect_error(surrogate$optimize(), class = "simpleError")
+  expect_error(surrogate$update(), class = "Mlr3ErrorLearnerTrain")
 
   # predict_type
   expect_equal(surrogate$predict_type, surrogate$learner$predict_type)

--- a/tests/testthat/test_SurrogateLearnerCollection.R
+++ b/tests/testthat/test_SurrogateLearnerCollection.R
@@ -29,7 +29,7 @@ test_that("SurrogateLearnerCollection API works", {
   expect_error(surrogate$update(), class = "Mlr3ErrorMboSurrogateUpdate")
 
   surrogate$param_set$values$catch_errors = FALSE
-  expect_error(surrogate$optimize(), class = "simpleError")
+  expect_error(surrogate$update(), class = "Mlr3ErrorLearnerTrain")
 
   # predict_type
   expect_equal(surrogate$predict_type, surrogate$learner[[1L]]$predict_type)


### PR DESCRIPTION
## Summary

- `test_SurrogateLearner.R` and `test_SurrogateLearnerCollection.R` contained a vacuous test: surrogates have no `$optimize()` method, so `expect_error(surrogate$optimize(), class = "simpleError")` passed on "attempt to apply non-function" without exercising anything.
- The tests now call `$update()` with `catch_errors = FALSE` and assert that the raw `Mlr3ErrorLearnerTrain` escapes unwrapped (instead of being upgraded to `Mlr3ErrorMboSurrogateUpdate`), covering the previously untested error path.

Addresses R48 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)