### PR TITLE
docs: add NEWS bullet for no-finished-evaluations fix in OptimizerAsyncMbo

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * fix: `AcqOptimizerLbfgsb` now raises a catchable acquisition function optimizer error instead of an unrelated error when no restart produces a valid solution, so the loop function can fall back to a randomly sampled point.
 * fix: `AcqOptimizerLbfgsb` no longer fails when the incumbent lies on a search space bound, which previously caused the optimization to silently degenerate into random search.
 * fix: `OptimizerADBO` and `TunerADBO` now draw the initial lambda from an exponential distribution as documented, so that the `lambda` parameter has an effect.
+* fix: `OptimizerAsyncMbo` now proposes a randomly sampled point when the archive contains no finished evaluations yet, instead of failing to train the surrogate on an empty archive.
 * fix: `OutputTrafoLog` and `OutputTrafoStandardize` no longer produce `NaN` or `Inf` values when all observed outcomes are identical.
 * fix: `ResultAssignerSurrogate` no longer errors when the archive contains duplicated x-configurations.
 * fix: `srlrn()` now correctly unwraps a single learner supplied in a list instead of erroring.


### PR DESCRIPTION
## Summary

- Commit 19b548c8 ("handle case with no finished evaluations in OptimizerAsyncMbo") was a user-facing bugfix but had no `NEWS.md` bullet.
- Adds the missing bullet in alphabetical position.

Addresses R49 of the 2026-07-17 package review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)