### PR TITLE
feat: use moocore instead of emoa for hypervolume computation

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -40,7 +40,6 @@ EHVI
 EHVIGH
 EIPS
 Emmerich
-emoa
 epsdom
 estim
 evals
@@ -73,6 +72,7 @@ matern
 mathjax
 maxeval
 mirai
+moocore
 mpcl
 msrs
 multiarch

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,12 +53,12 @@ Imports:
     R6 (>= 2.4.1)
 Suggests:
     DiceKriging,
-    emoa,
     fastGHQuad,
     lhs,
     mlr3learners (>= 0.12.0),
     mirai,
     mlr3pipelines (>= 0.5.2),
+    moocore,
     nloptr,
     processx,
     ranger,

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * fix: `AcqFunctionAEI` no longer errors during `$update()` when the surrogate model is not a `"regr.km"` model and now falls back to a noise variance of `0` as documented.
 * fix: `AcqFunctionEHVI`, `AcqFunctionEHVIGH`, and `AcqFunctionSmsEgo` now apply the surrogate's output transformation to `ys_front`, so the front and the reference point are compared on the same scale.
 * fix: `AcqFunctionEHVIGH` no longer prunes all Gauss-Hermite nodes when their weights are tied, which previously made the acquisition function identically `0` for `k = 2`.
+* feat: `AcqFunctionEHVIGH` now computes the hypervolume via the `moocore` package instead of `emoa`, which is no longer a dependency (#186).
 * fix: `AcqFunctionEI`, `AcqFunctionEILog`, `AcqFunctionPI`, and `AcqFunctionStochasticEI` now ignore the missing outcomes of pending evaluations when determining the best observed value, so `y_best` is no longer `NA` on an asynchronous archive with more than one worker.
 * fix: `AcqFunctionEIPS` now correctly divides the expected improvement by the predicted time instead of behaving like plain expected improvement.
 * fix: `AcqFunctionSmsEgo` now accepts a `lambda` below `1` during construction, consistent with the lower bound of its `constants` parameter set.

--- a/R/AcqFunctionEHVIGH.R
+++ b/R/AcqFunctionEHVIGH.R
@@ -108,7 +108,7 @@ AcqFunctionEHVIGH = R6Class(
         requires_predict_type_se = TRUE,
         surrogate_class = "SurrogateLearnerCollection",
         direction = "maximize",
-        packages = c("emoa", "fastGHQuad"),
+        packages = c("moocore", "fastGHQuad"),
         label = "Expected Hypervolume Improvement via GH Quadrature",
         man = "mlr3mbo::mlr_acqfunctions_ehvigh"
       )
@@ -139,7 +139,7 @@ AcqFunctionEHVIGH = R6Class(
       }
       self$ys_front = as.matrix(self$ys_front)
 
-      self$hypervolume = invoke(emoa::dominated_hypervolume, points = t(self$ys_front), ref = t(self$ref_point))
+      self$hypervolume = invoke(moocore::hypervolume, x = self$ys_front, reference = self$ref_point)
 
       # k because the multi-dimensional grid is created within adjust_gh_data
       self$gh_data = invoke(fastGHQuad::gaussHermiteData, n = self$constants$values$k)
@@ -173,7 +173,7 @@ AcqFunctionEHVIGH = R6Class(
         gh_data = adjust_gh_data(self$gh_data, mu = means[i, ], sigma = diag(vars[i, ]), r = r)
         hvs = map_dbl(seq_along(gh_data$weights), function(j) {
           ys = rbind(self$ys_front, gh_data$nodes[j, ] %*% diag(self$surrogate_max_to_min))
-          invoke(emoa::dominated_hypervolume, points = t(ys), ref = t(self$ref_point))
+          invoke(moocore::hypervolume, x = ys, reference = self$ref_point)
         })
         sum((hvs - self$hypervolume) * gh_data$weights, na.rm = TRUE)
       })

--- a/tests/testthat/test_AcqFunctionEHVIGH.R
+++ b/tests/testthat/test_AcqFunctionEHVIGH.R
@@ -1,5 +1,5 @@
 test_that("AcqFunctionEHVIGH works", {
-  skip_if_not_installed("emoa")
+  skip_if_not_installed("moocore")
   skip_if_not_installed("fastGHQuad")
   inst = MAKE_INST(OBJ_1D_2, PS_1D, trm("evals", n_evals = 5L))
   surrogate = SurrogateLearnerCollection$new(
@@ -16,7 +16,7 @@ test_that("AcqFunctionEHVIGH works", {
   expect_equal(acqf$domain, inst$search_space)
   expect_list(acqf$surrogate$learner, types = "Learner")
   expect_true(acqf$requires_predict_type_se)
-  expect_setequal(acqf$packages, c("emoa", "fastGHQuad"))
+  expect_setequal(acqf$packages, c("moocore", "fastGHQuad"))
 
   expect_r6(acqf$constants, "ParamSet")
   expect_equal(acqf$constants$ids(), c("k", "r"))
@@ -35,7 +35,7 @@ test_that("AcqFunctionEHVIGH works", {
 })
 
 test_that("AcqFunctionEHVIGH does not vanish for k = 2", {
-  skip_if_not_installed("emoa")
+  skip_if_not_installed("moocore")
   skip_if_not_installed("fastGHQuad")
   inst = MAKE_INST(OBJ_1D_2, PS_1D, trm("evals", n_evals = 5L))
   surrogate = SurrogateLearnerCollection$new(
@@ -56,7 +56,7 @@ test_that("AcqFunctionEHVIGH does not vanish for k = 2", {
 })
 
 test_that("AcqFunctionEHVIGH transforms ys_front onto the output trafo scale", {
-  skip_if_not_installed("emoa")
+  skip_if_not_installed("moocore")
   skip_if_not_installed("fastGHQuad")
   inst = MAKE_INST(OBJ_1D_2, PS_1D, trm("evals", n_evals = 5L))
   surrogate = SurrogateLearnerCollection$new(
@@ -88,7 +88,7 @@ test_that("AcqFunctionEHVIGH is close to AcqFunctionEHVI", {
   skip_if_not_installed("mlr3learners")
   skip_if_not_installed("DiceKriging")
   skip_if_not_installed("rgenoud")
-  skip_if_not_installed("emoa")
+  skip_if_not_installed("moocore")
   skip_if_not_installed("fastGHQuad")
   inst = MAKE_INST(OBJ_1D_2, PS_1D, trm("evals", n_evals = 5L))
   design = data.table(x = c(-0.8, -0.3, 0.6, 0.9))

--- a/tests/testthat/test_AcqFunctionMulti.R
+++ b/tests/testthat/test_AcqFunctionMulti.R
@@ -26,7 +26,7 @@ test_that("AcqFunctionMulti works for single-objective instances", {
 })
 
 test_that("AcqFunctionMulti works for multi-objective instances", {
-  skip_if_not_installed("emoa")
+  skip_if_not_installed("moocore")
   skip_if_not_installed("fastGHQuad")
   inst = MAKE_INST(OBJ_1D_2, PS_1D, trm("evals", n_evals = 5L))
   surrogate = SurrogateLearnerCollection$new(

--- a/tests/testthat/test_AcqOptimizer.R
+++ b/tests/testthat/test_AcqOptimizer.R
@@ -179,7 +179,7 @@ test_that("AcqOptimizer callbacks", {
 })
 
 test_that("AcqOptimizer warmstart respects warmstart_size for multi-crit archives", {
-  skip_if_not_installed("emoa")
+  skip_if_not_installed("moocore")
 
   instance = MAKE_INST(objective = OBJ_1D_2, search_space = PS_1D, terminator = trm("evals", n_evals = 20L))
   instance$eval_batch(data.table(x = seq(-1, 1, length.out = 8L)))

--- a/tests/testthat/test_bayesopt_emo.R
+++ b/tests/testthat/test_bayesopt_emo.R
@@ -16,7 +16,7 @@ test_that("default bayesopt_emo", {
   expect_true(sum(is.na(instance$archive$data$acq_ehvi)) == 4L)
   expect_true(!is.na(instance$archive$data$acq_ehvi[5L]))
 
-  skip_if_not_installed("emoa")
+  skip_if_not_installed("moocore")
   skip_if_not_installed("fastGHQuad")
   instance$archive$clear()
   acq_function = AcqFunctionEHVIGH$new()


### PR DESCRIPTION
## Summary

Closes #186. Follows the same switch already made in bbotk, replacing the `emoa` dependency with `moocore` for hypervolume computation.

`AcqFunctionEHVIGH` was the only place still using `emoa`, via two `emoa::dominated_hypervolume` calls. These are replaced with `moocore::hypervolume`. `AcqFunctionEHVI` computes EHVI analytically and never depended on `emoa`.

## Changes

- `R/AcqFunctionEHVIGH.R`: swap both `emoa::dominated_hypervolume` calls for `moocore::hypervolume`, and update the declared `packages`. moocore takes points as **rows** (emoa took **columns**), so the `t()` transposes are dropped.
- `DESCRIPTION`: replace `emoa` with `moocore` in `Suggests` (`moocore` is already an `Imports` of bbotk).
- Tests: update the `packages` assertion and the `skip_if_not_installed()` guards.
- `NEWS.md` and `.cspell/project-words.txt` updated.

## Verification

Numerically identical results were confirmed for 2- and 3-objective fronts:

```
emoa: 3.293036   moocore: 3.293036   diff: 0
3obj emoa: 5.197745   moocore: 5.197745
```

Affected test files pass: `AcqFunctionEHVIGH` (25), `bayesopt_emo` + `AcqFunctionMulti` (171).

🤖 Generated with [Claude Code](https://claude.com/claude-code)