### PR TITLE
refactor: drop old paradox compatibility leftovers

### DIFF
--- a/R/AcqFunction.R
+++ b/R/AcqFunction.R
@@ -243,7 +243,7 @@ AcqFunction = R6Class(
         self$surrogate_max_to_min = surrogate_mult_max_to_min(rhs)
         domain = generate_acq_domain(rhs)
         # lazy initialization requires this:
-        self$codomain = Codomain$new(get0("domains", codomain, ifnotfound = codomain$params)) # get0 for old paradox
+        self$codomain = Codomain$new(codomain$domains)
         self$domain = domain
       }
     },

--- a/R/AcqFunctionMulti.R
+++ b/R/AcqFunctionMulti.R
@@ -128,9 +128,7 @@ AcqFunctionMulti = R6Class(
       self$id = assert_string(id)
       self$domain = assert_param_set(domain)
       assert_param_set(codomain)
-      # get "codomain" element if present (new paradox) or default to $params (old paradox)
-      params = get0("domains", codomain, ifnotfound = codomain$params)
-      self$codomain = Codomain$new(params)
+      self$codomain = Codomain$new(codomain$domains)
       assert_names(self$domain$ids(), disjunct.from = self$codomain$ids())
       assert_names(self$domain$ids(), disjunct.from = c("x_domain", "timestamp", "batch_nr"))
       assert_names(self$codomain$ids(), disjunct.from = c("x_domain", "timestamp", "batch_nr"))
@@ -170,7 +168,7 @@ AcqFunctionMulti = R6Class(
         self$surrogate_max_to_min = surrogate_mult_max_to_min(rhs)
         domain = generate_acq_domain(rhs)
         # lazy initialization requires this:
-        self$codomain = Codomain$new(get0("domains", codomain, ifnotfound = codomain$params)) # get0 for old paradox
+        self$codomain = Codomain$new(codomain$domains)
         self$domain = domain
       }
     },

--- a/R/helper.R
+++ b/R/helper.R
@@ -28,19 +28,12 @@ generate_acq_multi_codomain = function(surrogate, acq_functions) {
 
 generate_acq_domain = function(surrogate) {
   assert_archive(surrogate$archive)
-  if ("set_id" %in% names(ps())) {
-    # old paradox
-    domain = surrogate$archive$search_space$clone(deep = TRUE)$subset(surrogate$cols_x)
-    domain$trafo = NULL
-  } else {
-    # get "domain" objects, set their .trafo-entry to NULL individually
-    dms = lapply(surrogate$archive$search_space$domains[surrogate$cols_x], function(x) {
-      x$.trafo[1] = list(NULL)
-      x
-    })
-    domain = do.call(ps, dms)
-  }
-  domain
+  # get "domain" objects, set their .trafo-entry to NULL individually
+  dms = lapply(surrogate$archive$search_space$domains[surrogate$cols_x], function(x) {
+    x$.trafo[1] = list(NULL)
+    x
+  })
+  do.call(ps, dms)
 }
 
 archive_xy = function(archive) {


### PR DESCRIPTION
Closes #171.

The package requires `paradox (>= 1.0.1)`, so the pre-1.0.0 fallbacks are dead code. This removes them:

- `generate_acq_domain()` (`R/helper.R`): drop the `"set_id" %in% names(ps())` old-paradox branch and always build the domain from `$domains`.
- `AcqFunction`/`AcqFunctionMulti` (`R/AcqFunction.R`, `R/AcqFunctionMulti.R`): replace `get0("domains", codomain, ifnotfound = codomain$params)` with `codomain$domains`.

Pure refactoring with no user-facing behavior change, so no `NEWS.md` entry.

Tests: `test_AcqFunction` (50 pass) and `test_AcqFunctionMulti` (157 pass) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)