### PR TITLE
test: skip multi-crit warmstart test when emoa is missing

### DIFF
--- a/tests/testthat/test_AcqOptimizer.R
+++ b/tests/testthat/test_AcqOptimizer.R
@@ -179,7 +179,7 @@ test_that("AcqOptimizer callbacks", {
 })
 
 test_that("AcqOptimizer warmstart respects warmstart_size for multi-crit archives", {
-  skip_if_not_installed("moocore")
+  skip_if_not_installed("emoa")
 
   instance = MAKE_INST(objective = OBJ_1D_2, search_space = PS_1D, terminator = trm("evals", n_evals = 20L))
   instance$eval_batch(data.table(x = seq(-1, 1, length.out = 8L)))


### PR DESCRIPTION
## Problem

The [no-suggest check](https://github.com/mlr-org/mlr3mbo/actions/runs/29813885752/job/88580675919) fails with:

```
── Error ('test_AcqOptimizer.R'): AcqOptimizer warmstart respects warmstart_size for multi-crit archives ──
Error: The following packages could not be loaded: emoa
Backtrace:
  └─self$acq_function$archive$nds_selection(n_select = n_select)
    └─bbotk:::.__ArchiveBatch__nds_selection(...)
      └─bbotk::nds_selection(points, n_select, ref_point, minimize)
```

## Cause

Commit a86075cf (moocore migration) changed this test's skip from `emoa` to `moocore`. But this test exercises the smsego warmstart path, which goes through `bbotk::nds_selection()`. That function still requires `emoa` (via `nds_rank()` and `hypervolume_contribution()`) — only the plain hypervolume calls were migrated to moocore. So in the no-suggest environment `moocore` was present (skip didn't trigger) while `emoa` was absent, and the test errored.

## Fix

Skip on `emoa` instead of `moocore`, matching what the code path actually needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)