### PR TITLE
test: replace pima task with sonar

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -118,7 +118,7 @@ library(mlr3tuning)
 library(mlr3mbo)
 set.seed(1)
 
-task = tsk("pima")
+task = tsk("sonar")
 
 learner = lrn("classif.rpart", cp = to_tune(lower = 1e-04, upper = 1, logscale = TRUE))
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ library(mlr3tuning)
 library(mlr3mbo)
 set.seed(1)
 
-task = tsk("pima")
+task = tsk("sonar")
 
 learner = lrn("classif.rpart", cp = to_tune(lower = 1e-04, upper = 1, logscale = TRUE))
 

--- a/attic/test_TunerADBO.R
+++ b/attic/test_TunerADBO.R
@@ -7,7 +7,7 @@ test_that("adbo tuner works", {
 
   rush::rush_plan(n_workers = 4)
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3),
     measure = msr("classif.ce"),
@@ -35,7 +35,7 @@ test_that("adbo works with transformation functions", {
 
   rush::rush_plan(n_workers = 2)
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3),
     measure = msr("classif.ce"),
@@ -64,7 +64,7 @@ test_that("search works with dependencies", {
 
   rush::rush_plan(n_workers = 2)
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3),
     measure = msr("classif.ce"),
@@ -99,7 +99,7 @@ test_that("adbo works with branching", {
 
   rush::rush_plan(n_workers = 2)
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = graph_learner,
     resampling = rsmp("cv", folds = 3),
     measure = msr("classif.ce"),

--- a/tests/testthat/test_ResultAssignerArchive.R
+++ b/tests/testthat/test_ResultAssignerArchive.R
@@ -91,7 +91,7 @@ test_that("ResultAssignerArchive passes internal tuned values", {
   )
 
   instance = ti(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3L),
     measures = msr("classif.ce"),

--- a/tests/testthat/test_ResultAssignerSurrogate.R
+++ b/tests/testthat/test_ResultAssignerSurrogate.R
@@ -142,7 +142,7 @@ test_that("ResultAssignerSurrogate passes internal tuned values", {
   )
 
   instance = ti(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3L),
     measures = msr("classif.ce"),

--- a/tests/testthat/test_TunerADBO.R
+++ b/tests/testthat/test_TunerADBO.R
@@ -11,7 +11,7 @@ test_that("TunerADBO works", {
   learner = lrn("classif.rpart", minsplit = to_tune(2L, 128L), cp = to_tune(1e-04, 1e-1))
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3L),
     measures = msr("classif.ce"),

--- a/tests/testthat/test_TunerAsyncMbo.R
+++ b/tests/testthat/test_TunerAsyncMbo.R
@@ -11,7 +11,7 @@ test_that("TunerAsyncMbo works", {
   learner = lrn("classif.rpart", minsplit = to_tune(2L, 128L), cp = to_tune(1e-04, 1e-1))
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3L),
     measures = msr("classif.ce"),


### PR DESCRIPTION
## Summary

The `pima` task was removed from mlr3 because the underlying `PimaIndiansDiabetes2` dataset was dropped from the mlbench package.

This PR replaces all `tsk("pima")` usages with `tsk("sonar")`, another binary classification task that serves as a clean drop-in for the affected tuning and optimization examples and tests.

## Changes

- `README.Rmd` / `README.md`: tuning example task
- `tests/testthat/test_TunerADBO.R`
- `tests/testthat/test_TunerAsyncMbo.R`
- `tests/testthat/test_ResultAssignerArchive.R`
- `tests/testthat/test_ResultAssignerSurrogate.R`
- `attic/test_TunerADBO.R`

All usages were plain `tsk("pima")` calls with no pima-specific assertions (feature counts, target/positive class, etc.), so no further adjustments were needed. `sonar` is likewise binary classification with no missing values.

## Tests

Ran the four affected test files locally (Redis running for async tests): 54 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)