### PR TITLE
Use the public transform-free subset API on Paradox 2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # mlr3mbo (development version)
 
+* compatibility: use Paradox 2's public transformation-free subset API while
+  retaining support for Paradox 1.
+
 # mlr3mbo 1.2.1
 
 * compatibility: mlr3 1.7.2
@@ -188,4 +191,3 @@
 # mlr3mbo 0.1.1
 
 * Initial upload to CRAN.
-

--- a/R/helper.R
+++ b/R/helper.R
@@ -28,12 +28,20 @@ generate_acq_multi_codomain = function(surrogate, acq_functions) {
 
 generate_acq_domain = function(surrogate) {
   assert_archive(surrogate$archive)
-  # get "domain" objects, set their .trafo-entry to NULL individually
-  dms = lapply(surrogate$archive$search_space$domains[surrogate$cols_x], function(x) {
-    x$.trafo[1] = list(NULL)
-    x
-  })
-  do.call(ps, dms)
+  if (utils::packageVersion("paradox") >= numeric_version("2.0.0")) {
+    domain = surrogate$archive$search_space$subset(
+      surrogate$cols_x,
+      keep_trafo = FALSE
+    )
+  } else {
+    # get "domain" objects, set their .trafo-entry to NULL individually
+    dms = lapply(surrogate$archive$search_space$domains[surrogate$cols_x], function(x) {
+      x$.trafo[1] = list(NULL)
+      x
+    })
+    domain = do.call(ps, dms)
+  }
+  domain
 }
 
 archive_xy = function(archive) {

--- a/tests/testthat/test_AcqFunction.R
+++ b/tests/testthat/test_AcqFunction.R
@@ -160,6 +160,7 @@ test_that("AcqFunction generate_acq_domain works", {
   domain = generate_acq_domain(surrogate)
   expect_equal(domain, OBJ_2D$domain)
   expect_false(domain$has_trafo)
+  expect_true(inst$search_space$has_trafo)
 
   surrogate$cols_x = "x2"
   domain = generate_acq_domain(surrogate)


### PR DESCRIPTION
> Paradox 2 deliberately makes detached Domain internals non-authoritative and
> provides `ParamSet$subset(..., keep_trafo = FALSE)` for constructing a
> transformation-free acquisition domain. Use that public API on Paradox 2
> instead of deleting the private `.trafo` column returned by `$domains`.
> Retain both historical implementations for Paradox 1, so the package remains
> dual-version compatible. Extend the existing acquisition-domain regression to
> verify that producing the detached domain does not remove transformations
> from the source search space, and record the migration in NEWS.

- **Use public transform-free Paradox 2 subsets**
- **Document the Paradox 2 subset migration**
